### PR TITLE
add recovery function to grpc server side

### DIFF
--- a/service/grpc_recovery/interceptors.go
+++ b/service/grpc_recovery/interceptors.go
@@ -1,0 +1,67 @@
+// Copyright 2017 David Ackroyd. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_recovery
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// RecoveryHandlerFunc is a function that recovers from the panic `p` by returning an `error`.
+type RecoveryHandlerFunc func(p interface{}) (err error)
+
+// RecoveryHandlerFuncContext is a function that recovers from the panic `p` by returning an `error`.
+// The context can be used to extract request scoped metadata and context values.
+type RecoveryHandlerFuncContext func(ctx context.Context, p interface{}) (err error)
+
+// UnaryServerInterceptor returns a new unary server interceptor for panic recovery.
+func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
+	o := evaluateOptions(opts)
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (_ interface{}, err error) {
+		panicked := true
+
+		defer func() {
+			if r := recover(); r != nil || panicked {
+				fmt.Printf("%s\n", r)
+				fmt.Printf("\n\n\n Start Service Again\n")
+				err = recoverFrom(ctx, r, o.recoveryHandlerFunc)
+			}
+		}()
+
+		resp, err := handler(ctx, req)
+		panicked = false
+		return resp, err
+	}
+}
+
+// StreamServerInterceptor returns a new streaming server interceptor for panic recovery.
+func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
+	o := evaluateOptions(opts)
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+		panicked := true
+
+		defer func() {
+			if r := recover(); r != nil || panicked {
+				fmt.Printf("%s\n", r)
+				fmt.Printf("\n\n\n Start Service Again\n")
+				err = recoverFrom(stream.Context(), r, o.recoveryHandlerFunc)
+			}
+		}()
+
+		err = handler(srv, stream)
+		panicked = false
+		return err
+	}
+}
+
+func recoverFrom(ctx context.Context, p interface{}, r RecoveryHandlerFuncContext) error {
+	if r == nil {
+		return status.Errorf(codes.Internal, "%v", p)
+	}
+	return r(ctx, p)
+}

--- a/service/grpc_recovery/options.go
+++ b/service/grpc_recovery/options.go
@@ -1,0 +1,43 @@
+// Copyright 2017 David Ackroyd. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_recovery
+
+import "context"
+
+var (
+	defaultOptions = &options{
+		recoveryHandlerFunc: nil,
+	}
+)
+
+type options struct {
+	recoveryHandlerFunc RecoveryHandlerFuncContext
+}
+
+func evaluateOptions(opts []Option) *options {
+	optCopy := &options{}
+	*optCopy = *defaultOptions
+	for _, o := range opts {
+		o(optCopy)
+	}
+	return optCopy
+}
+
+type Option func(*options)
+
+// WithRecoveryHandler customizes the function for recovering from a panic.
+func WithRecoveryHandler(f RecoveryHandlerFunc) Option {
+	return func(o *options) {
+		o.recoveryHandlerFunc = RecoveryHandlerFuncContext(func(ctx context.Context, p interface{}) error {
+			return f(p)
+		})
+	}
+}
+
+// WithRecoveryHandlerContext customizes the function for recovering from a panic.
+func WithRecoveryHandlerContext(f RecoveryHandlerFuncContext) Option {
+	return func(o *options) {
+		o.recoveryHandlerFunc = f
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aldelo/connector/adapters/registry"
 	"github.com/aldelo/connector/adapters/registry/sdoperationstatus"
 	"github.com/aldelo/connector/adapters/tracer"
+	"github.com/aldelo/connector/service/grpc_recovery"
 	ws "github.com/aldelo/connector/webserver"
 	sns2 "github.com/aws/aws-sdk-go/service/sns"
 	"google.golang.org/grpc"
@@ -326,6 +327,8 @@ func (s *Service) setupServer() (lis net.Listener, ip string, port uint, err err
 			s.UnaryServerInterceptors = append(s.UnaryServerInterceptors, tracer.TracerUnaryServerInterceptor)
 		}
 
+		s.UnaryServerInterceptors = append(s.UnaryServerInterceptors, grpc_recovery.UnaryServerInterceptor())
+
 		count := len(s.UnaryServerInterceptors)
 
 		if count == 1 {
@@ -338,6 +341,8 @@ func (s *Service) setupServer() (lis net.Listener, ip string, port uint, err err
 		if xray.XRayServiceOn() {
 			s.StreamServerInterceptors = append(s.StreamServerInterceptors, tracer.TracerStreamServerInterceptor)
 		}
+
+		s.StreamServerInterceptors = append(s.StreamServerInterceptors, grpc_recovery.StreamServerInterceptor())
 
 		count = len(s.StreamServerInterceptors)
 


### PR DESCRIPTION
i find my grpc server will keep break by bug codes, but i do not want it just stop. so i add recovery function code to stop server break from nil bug. this code are from github gRPC Ecosystem 

https://github.com/grpc-ecosystem/go-grpc-middleware/tree/b6d97fab8b7d7d99cb5a9ee1ea17afbb2b12e84c 