### PR TITLE
Use sync.Mutex to fix schemeMap concurrency issue and uses DynamoDBTableKeyValue instead of DynamoDBTableKeys

### DIFF
--- a/notifiergateway/model/model.go
+++ b/notifiergateway/model/model.go
@@ -18,13 +18,14 @@ package model
 
 import (
 	"fmt"
+	"time"
+
 	util "github.com/aldelo/common"
 	"github.com/aldelo/common/wrapper/aws/awsregion"
 	"github.com/aldelo/common/wrapper/dynamodb"
 	"github.com/aldelo/connector/notifiergateway/config"
 	"github.com/aws/aws-sdk-go/aws"
 	ddb "github.com/aws/aws-sdk-go/service/dynamodb"
-	"time"
 )
 
 var DynamoDBActionRetryAttempts uint
@@ -214,13 +215,13 @@ func SetInstanceHealthToDataStore(namespaceId string, serviceId string, instance
 	}
 }
 
-func DeleteInstanceHealthFromDataStore(instanceKeys ...*dynamodb.DynamoDBTableKeys) (deleteFailKeys []*dynamodb.DynamoDBTableKeys, err error) {
+func DeleteInstanceHealthFromDataStore(instanceKeys ...*dynamodb.DynamoDBTableKeyValue) (deleteFailKeys []*dynamodb.DynamoDBTableKeyValue, err error) {
 	if _ddbStore == nil {
-		return []*dynamodb.DynamoDBTableKeys{}, fmt.Errorf("Delete Instance Health From Data Store Failed: DynamoDB Connection Not Established")
+		return []*dynamodb.DynamoDBTableKeyValue{}, fmt.Errorf("Delete Instance Health From Data Store Failed: DynamoDB Connection Not Established")
 	}
 
 	if len(instanceKeys) == 0 {
-		return []*dynamodb.DynamoDBTableKeys{}, fmt.Errorf("Delete Instance Health From Data Store Failed: %s", "InstanceKeys To Delete is Required")
+		return []*dynamodb.DynamoDBTableKeyValue{}, fmt.Errorf("Delete Instance Health From Data Store Failed: %s", "InstanceKeys To Delete is Required")
 	}
 
 	if deleteFailKeys, err = _ddbStore.BatchDeleteItemsWithRetry(_ddbActionRetries, _ddbStore.TimeOutDuration(_ddbTimeoutSeconds), instanceKeys...); err != nil {
@@ -234,7 +235,7 @@ func DeleteInstanceHealthFromDataStore(instanceKeys ...*dynamodb.DynamoDBTableKe
 		}
 	} else {
 		// delete all success
-		return []*dynamodb.DynamoDBTableKeys{}, nil
+		return []*dynamodb.DynamoDBTableKeyValue{}, nil
 	}
 }
 


### PR DESCRIPTION
1, Fix concurrency issue: uses sync.Mutex to provide thread-safety for accessing and modifying schemeMap

2, Uses DynamoDBTableKeyValue instead of DynamoDBTableKeys, which is one of code changes of ddb wrapper in common lib last month