### PR TITLE
chore(deps): bump aldelo/common v1.8.8 → v1.8.10 (+ quic-go 0.59.1, subsumes #41)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aldelo/connector
 go 1.26.2
 
 require (
-	github.com/aldelo/common v1.8.8
+	github.com/aldelo/common v1.8.10
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/aws/aws-xray-sdk-go v1.8.5
 	github.com/gin-contrib/cors v1.7.6
@@ -66,7 +66,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5 h1:rFw4nCn9iMW+Vajsk51NtYIcwSTkXr+JGrMd36kTDJw=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
-github.com/aldelo/common v1.8.8 h1:EgAEXUrRBt2g/zIHA8TA58x7kRfGqqXOl9/WOvbNZXw=
-github.com/aldelo/common v1.8.8/go.mod h1:GSbbYqtfevAO3oMQ4HJBVVFBXnZ7xrXa+J8J2/SgtWE=
+github.com/aldelo/common v1.8.10 h1:h2lyNJD/XTZzB2APe7puXAS7GiWB8xwh/BHYNdVTPv4=
+github.com/aldelo/common v1.8.10/go.mod h1:gmgGyqUTl1Y9pWncbLGz9bdbEjBqxX8sXv+eWLzIjVo=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antlr/antlr4 v0.0.0-20200820155224-be881fa6b91d h1:OE3kzLBpy7pOJEzE55j9sdgrSilUPzzj++FWvp1cmIs=
@@ -169,8 +169,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/quasoft/memstore v0.0.0-20180925164028-84a050167438/go.mod h1:wTPjTepVu7uJBYgZ0SdWHQlIas582j6cn2jgk4DDdlg=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=


### PR DESCRIPTION
## What
Bump `github.com/aldelo/common` v1.8.8 → **v1.8.10** + `go mod tidy`.

Common v1.8.10 is the security release (gin error-helper unsafe-quoting → `encoding/json`; quic-go CVE bump). The tidy transitively upgrades **quic-go v0.59.0 → v0.59.1** (`GHSA-vvgj-x9jq-8cj9`).

## Resolves
- Dependabot alert **#16** (quic-go) — quic-go now at 0.59.1.
- **Supersedes PR #41** (dependabot's quic-go-0.59.1 bump) — same end state, reached via the common bump.

## Verification (local, go 1.26.2)
- `go build ./...` clean · `go vet ./...` clean
- `go test ./... -short`: 26 ok / 10 no-test. The `service` package's timing flake is **pre-existing** (passes isolated; unrelated to this deps-only change).

## Blast radius
go.mod (4 lines) + go.sum (8 lines) only. No source changes. No interface/behavior impact on integrators.