### PR TITLE
fix(notifiergateway): self-contained sanitizeSNSUrl — clears CodeQL SSRF #37 (DRY-refactor regression)

### DIFF
--- a/notifiergateway/notifiergateway.go
+++ b/notifiergateway/notifiergateway.go
@@ -235,9 +235,20 @@ var snsTopicArnPattern = regexp.MustCompile(`^arn:aws:sns:[a-z0-9-]+:\d{12}:[A-Z
 // the $ anchor). Kept package-level for compile-once performance.
 var snsHostPattern = regexp.MustCompile(`^sns\.[a-z0-9-]+\.amazonaws\.com$`)
 
-// validateSNSURL parses rawUrl and validates it against the AWS SNS host
-// allowlist. Returns the parsed *url.URL (with host lowercased) and true
-// if the URL is a legitimate SNS endpoint; (nil, false) otherwise.
+// sanitizeSNSUrl parses rawUrl, validates it against the AWS SNS host
+// allowlist, and reconstructs a clean URL from the validated components.
+// It is the single source of truth for SNS URL validation — isValidSNSUrl
+// delegates here — so the bool-gate and the reconstruct-gate can never drift
+// (the root cause of the S1/S2 SSRF siblings).
+//
+// The parse, the allowlist check, and the reconstruction are deliberately
+// kept in ONE function (rather than returning a *url.URL across a function
+// boundary): a regex MatchString alone is not a CodeQL-recognized
+// request-forgery barrier, but the in-function parse→allowlist→reconstruct
+// flow — building a fresh url.URL with a constant https scheme and a host
+// that just passed the allowlist — is what severs CodeQL's taint chain from
+// the attacker-controlled rawUrl. Splitting it across functions reintroduces
+// the SSRF alert (CodeQL #37). Do not re-extract a returning validator.
 //
 // Validation checks (all must pass):
 //   - Scheme must be "https"
@@ -247,81 +258,66 @@ var snsHostPattern = regexp.MustCompile(`^sns\.[a-z0-9-]+\.amazonaws\.com$`)
 //   - Hostname must exactly match sns.<region>.amazonaws.com (anchored regex)
 //   - Path must be non-empty (at least "/") or a query string present
 //
-// This is the single source of truth for SNS URL validation — both
-// isValidSNSUrl and sanitizeSNSUrl delegate here. Keeping one
-// implementation eliminates drift between the bool-gate and the
-// reconstruct-gate (the root cause of the S1/S2 SSRF siblings).
-func validateSNSURL(rawUrl string) (*url.URL, bool) {
+// Returns the sanitized (reconstructed) URL and true, or ("", false) on
+// validation failure.
+func sanitizeSNSUrl(rawUrl string) (string, bool) {
 	u, err := url.Parse(rawUrl)
 	if err != nil {
-		return nil, false
+		return "", false
 	}
 
 	// Reject non-https schemes (prevents http:// downgrade and exotic schemes)
 	if !strings.EqualFold(u.Scheme, "https") {
-		return nil, false
+		return "", false
 	}
 
-	// Reject opaque URLs
+	// Reject opaque URLs (e.g. "https:opaque")
 	if u.Opaque != "" {
-		return nil, false
+		return "", false
 	}
 
-	// Reject embedded credentials
+	// Reject embedded credentials (user:pass@ or @host)
 	if u.User != nil {
-		return nil, false
+		return "", false
 	}
 
 	host := strings.ToLower(u.Hostname())
 
-	// Reject explicit port
+	// Reject explicit port — legitimate AWS SNS URLs never carry a port
 	if u.Port() != "" {
-		return nil, false
-	}
-
-	// Exact hostname match: sns.<region>.amazonaws.com — rejects subdomain
-	// suffix attacks (sns.us-east-1.amazonaws.com.evil.com) via $ anchor
-	if !snsHostPattern.MatchString(host) {
-		return nil, false
-	}
-
-	// Require a path (at least "/") — URLs without a path are malformed for our use
-	if u.Path == "" && u.RawQuery == "" {
-		return nil, false
-	}
-
-	// Normalize host to lowercase for consistent reconstruction
-	u.Host = host
-	return u, true
-}
-
-// isValidSNSUrl validates that a URL matches the expected AWS SNS domain pattern
-// to prevent SSRF attacks via attacker-controlled SubscribeURL/UnsubscribeURL.
-// Delegates to validateSNSURL for the actual checks.
-func isValidSNSUrl(rawUrl string) bool {
-	_, ok := validateSNSURL(rawUrl)
-	return ok
-}
-
-// sanitizeSNSUrl parses and validates a URL against the SNS host allowlist,
-// then reconstructs it from the parsed components. The reconstructed URL
-// severs the CodeQL taint chain because it is derived from validated,
-// parsed fields rather than from the original attacker-controlled string.
-// Returns the sanitized URL and true, or ("", false) if validation fails.
-func sanitizeSNSUrl(rawUrl string) (string, bool) {
-	u, ok := validateSNSURL(rawUrl)
-	if !ok {
 		return "", false
 	}
 
-	// Reconstruct from parsed components — severs taint from rawUrl
+	// Exact hostname match: sns.<region>.amazonaws.com — rejects subdomain
+	// suffix attacks (sns.us-east-1.amazonaws.com.evil.com) via the $ anchor.
+	if !snsHostPattern.MatchString(host) {
+		return "", false
+	}
+
+	// Require a path (at least "/") or a query — URLs without either are
+	// malformed for our use.
+	if u.Path == "" && u.RawQuery == "" {
+		return "", false
+	}
+
+	// Reconstruct from the validated components. `host` has just passed the
+	// allowlist; a fresh url.URL with a constant https scheme severs the taint.
 	clean := &url.URL{
 		Scheme:   "https",
-		Host:     u.Host,
+		Host:     host,
 		Path:     u.Path,
 		RawQuery: u.RawQuery,
 	}
 	return clean.String(), true
+}
+
+// isValidSNSUrl reports whether rawUrl is a legitimate AWS SNS endpoint, to
+// prevent SSRF via attacker-controlled SubscribeURL/UnsubscribeURL. It
+// delegates to sanitizeSNSUrl (discarding the reconstructed URL) so the
+// bool-gate and the reconstruct-gate share one implementation.
+func isValidSNSUrl(rawUrl string) bool {
+	_, ok := sanitizeSNSUrl(rawUrl)
+	return ok
 }
 
 // healthreporter handles client reporting to host health status of the client,

--- a/notifiergateway/notifiergateway_test.go
+++ b/notifiergateway/notifiergateway_test.go
@@ -790,29 +790,27 @@ func TestCertChainVerification_FailureIsWarnNotReject(t *testing.T) {
 }
 
 // =========================================================================
-// Group G — DRY refactor: validateSNSURL regression
+// Group G — DRY: sanitizeSNSUrl is the single self-contained validator/
+// reconstructor; isValidSNSUrl delegates to it (no separate validateSNSURL —
+// splitting it across functions reintroduced CodeQL SSRF #37).
 // =========================================================================
 
-// TestValidateSNSURL_ReturnsParsedURL verifies that validateSNSURL returns
-// the parsed *url.URL with lowercase host (the DRY refactor's core output).
-func TestValidateSNSURL_ReturnsParsedURL(t *testing.T) {
-	u, ok := validateSNSURL("https://SNS.us-east-1.AMAZONAWS.COM/cert.pem")
+// TestSanitizeSNSUrl_NormalizesAndReconstructs verifies sanitizeSNSUrl
+// lowercases the host and reconstructs a clean https URL (the canonical
+// validation output that both isValidSNSUrl and the GET sites rely on).
+func TestSanitizeSNSUrl_NormalizesAndReconstructs(t *testing.T) {
+	clean, ok := sanitizeSNSUrl("https://SNS.us-east-1.AMAZONAWS.COM/cert.pem")
 	if !ok {
 		t.Fatal("expected valid URL to pass validation")
 	}
-	if u.Host != "sns.us-east-1.amazonaws.com" {
-		t.Errorf("expected lowercase host, got %q", u.Host)
-	}
-	if u.Scheme != "https" {
-		t.Errorf("expected https scheme, got %q", u.Scheme)
-	}
-	if u.Path != "/cert.pem" {
-		t.Errorf("expected /cert.pem path, got %q", u.Path)
+	if clean != "https://sns.us-east-1.amazonaws.com/cert.pem" {
+		t.Errorf("expected reconstructed lowercase https URL, got %q", clean)
 	}
 }
 
-// TestValidateSNSURL_RejectsAttack verifies validateSNSURL rejects attack vectors.
-func TestValidateSNSURL_RejectsAttack(t *testing.T) {
+// TestSanitizeSNSUrl_RejectsAttack verifies the canonical validator rejects
+// attack vectors (via both sanitizeSNSUrl and the isValidSNSUrl delegate).
+func TestSanitizeSNSUrl_RejectsAttack(t *testing.T) {
 	attacks := []string{
 		"https://attacker.example.com/cert.pem",
 		"http://sns.us-east-1.amazonaws.com/cert.pem",
@@ -821,8 +819,11 @@ func TestValidateSNSURL_RejectsAttack(t *testing.T) {
 		"",
 	}
 	for _, url := range attacks {
-		if _, ok := validateSNSURL(url); ok {
-			t.Errorf("validateSNSURL(%q) should have been rejected", url)
+		if _, ok := sanitizeSNSUrl(url); ok {
+			t.Errorf("sanitizeSNSUrl(%q) should have been rejected", url)
+		}
+		if isValidSNSUrl(url) {
+			t.Errorf("isValidSNSUrl(%q) should have been rejected", url)
 		}
 	}
 }


### PR DESCRIPTION
The deep-review DRY refactor (#45) extracted `validateSNSURL` (returning `*url.URL`) and had `sanitizeSNSUrl` reconstruct from the returned pointer's fields. That broke CodeQL's **interprocedural** request-forgery barrier recognition — the parse taint flowed through the returned `*url.URL` into the reconstruction, re-flagging the cert-fetch GET as SSRF (**new critical alert #37**, `snssigverify.go:309`).

## Fix
Keep DRY but restore the CodeQL-cleared shape: `sanitizeSNSUrl` is the single **self-contained** function again (parse + host-allowlist + reconstruct inline — exactly the PR #44 pattern CodeQL recognized), and `isValidSNSUrl` delegates **down** to it (discarding the reconstructed string). No separate returning validator.

**Security unchanged** — identical checks, identical reconstruction; the SubscribeURL/UnsubscribeURL/cert-fetch sites all still use the reconstructed URL. Tests updated (`TestSanitizeSNSUrl_*` replace `TestValidateSNSURL_*`).

`go build/vet ./...` clean · `gofmt` clean · notifiergateway `-race` green (incl. the SSRF/unsubscribe regression tests). Expected: CodeQL #37 clears, 0 open alerts.