### PR TITLE
fix(notifiergateway): escape ALL control bytes in logs + serverUrl sites (F-1/F-3)

### DIFF
--- a/notifiergateway/notifiergateway.go
+++ b/notifiergateway/notifiergateway.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	util "github.com/aldelo/common"
 	"github.com/aldelo/common/crypto"
@@ -205,26 +206,30 @@ func NewNotifierGateway(appName string, configFileNameWebServer string, configFi
 	return gatewayServer, nil
 }
 
-// escapeUserInput replaces control characters and Unicode line/paragraph
-// separators with spaces to mitigate log-injection (CWE-117). Covers:
-//   - \n, \r, \t — standard ASCII control chars
-//   - U+0085 (NEL / Next Line)
-//   - U+2028 (Line Separator)
-//   - U+2029 (Paragraph Separator)
+// escapeUserInput neutralizes log-forging / terminal-injection vectors
+// (CWE-117) in untrusted data before it is written to a log line. It maps
+// every Unicode control character to a space: C0 (0x00-0x1F, including
+// CR/LF/TAB/NUL/BS/ESC/BEL/VT/FF), DEL (0x7F), and C1 (0x80-0x9F, including
+// NEL U+0085). It also maps the Unicode line and paragraph separators
+// (U+2028/U+2029) to a space; these are categories Zl/Zp, NOT control, so
+// unicode.IsControl does not cover them and they are handled explicitly.
 //
-// Go RE2's \s matches ASCII whitespace only; these Unicode separators
-// require explicit handling (see Go regexp \p{Z}\p{Cf} lesson).
-var logInjectionReplacer = strings.NewReplacer(
-	"\n", " ",
-	"\r", " ",
-	"\t", " ",
-	"\u0085", " ", // NEL (Next Line)
-	"\u2028", " ", // Line Separator
-	"\u2029", " ", // Paragraph Separator
-)
-
+// This prevents an attacker-supplied value (e.g. an SNS MessageId or a
+// relayed server URL) from injecting newlines to forge log lines, ANSI
+// escape sequences to clear/recolor the operator's terminal, or backspace/NUL
+// to hide and overwrite previously logged text. Ordinary printable runes and
+// non-control multi-byte runes are preserved.
+//
+// Fix: F-1/F-3 (deep-review-2026-06-14 contrarian re-review). The prior
+// strings.Replacer only stripped CR/LF/TAB and the Unicode separators, leaving
+// ESC (0x1B) and the other C0/DEL control bytes to pass through unescaped.
 func escapeUserInput(data string) string {
-	return logInjectionReplacer.Replace(data)
+	return strings.Map(func(r rune) rune {
+		if r == '\u2028' || r == '\u2029' || unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, data)
 }
 
 var snsTopicArnPattern = regexp.MustCompile(`^arn:aws:sns:[a-z0-9-]+:\d{12}:[A-Za-z0-9_-]{1,256}$`)
@@ -1025,7 +1030,7 @@ func snsnotification(c *gin.Context, serverKey string) {
 		} else {
 			// perform sns notification routing task
 			if notifyJson, err := util.MarshalJSONCompact(notify); err != nil {
-				log.Printf("Server Key %s at Host %s Marshal Notification Data to JSON Failed: %s", escapeUserInput(serverKey), serverUrl, err.Error())
+				log.Printf("Server Key %s at Host %s Marshal Notification Data to JSON Failed: %s", escapeUserInput(serverKey), escapeUserInput(serverUrl), err.Error())
 				c.String(412, "Notification Marshal Failed")
 
 				if seg != nil && seg.Ready() {
@@ -1035,7 +1040,7 @@ func snsnotification(c *gin.Context, serverKey string) {
 				// relay sns notification to target notify server
 				// FIX S6: Escape notifyJson for logging — the raw notifyJson
 				// passed to the POST below stays unescaped.
-				log.Println("/snsrouter 'notification' Relaying SNS Data To Notifier Server Endpoint '" + serverUrl + "': " + escapeUserInput(notifyJson))
+				log.Println("/snsrouter 'notification' Relaying SNS Data To Notifier Server Endpoint '" + escapeUserInput(serverUrl) + "': " + escapeUserInput(notifyJson))
 
 				serverUrl += "/snsrelay"
 
@@ -1045,21 +1050,21 @@ func snsnotification(c *gin.Context, serverKey string) {
 						Value: "application/json",
 					},
 				}, notifyJson); err != nil {
-					log.Printf("Server Key %s at Host %s Route Notification From SNS to Internal Host Failed: %s", escapeUserInput(serverKey), serverUrl, err.Error())
+					log.Printf("Server Key %s at Host %s Route Notification From SNS to Internal Host Failed: %s", escapeUserInput(serverKey), escapeUserInput(serverUrl), err.Error())
 					c.String(412, "Route Notification to Internal Host Failed")
 
 					if seg != nil && seg.Ready() {
 						xray.LogXrayAddFailure("NotifierGateway", seg.SafeAddError(fmt.Errorf("Server Key %s at Host %s Route Notification From SNS to Internal Host Failed: %w", escapeUserInput(serverKey), serverUrl, err)))
 					}
 				} else if statusCode != 200 {
-					log.Printf("Server Key %s at Host %s Route Notification From SNS to Internal Host Did Not Yield Status Code 200: Actual Code = %d", escapeUserInput(serverKey), serverUrl, statusCode)
+					log.Printf("Server Key %s at Host %s Route Notification From SNS to Internal Host Did Not Yield Status Code 200: Actual Code = %d", escapeUserInput(serverKey), escapeUserInput(serverUrl), statusCode)
 					c.Status(statusCode)
 
 					if seg != nil && seg.Ready() {
 						xray.LogXrayAddFailure("NotifierGateway", seg.SafeAddError(fmt.Errorf("Server Key %s at Host %s Route Notification From SNS to Internal Host Did Not Yield Status Code 200: Actual Code = %d", escapeUserInput(serverKey), serverUrl, statusCode)))
 					}
 				} else {
-					log.Printf("Server Key %s at Host %s Route Notification Complete", escapeUserInput(serverKey), serverUrl)
+					log.Printf("Server Key %s at Host %s Route Notification Complete", escapeUserInput(serverKey), escapeUserInput(serverUrl))
 					c.Status(200)
 				}
 			}

--- a/notifiergateway/notifiergateway_test.go
+++ b/notifiergateway/notifiergateway_test.go
@@ -374,6 +374,70 @@ func TestEscapeUserInput_StripsCRLF(t *testing.T) {
 	}
 }
 
+// TestEscapeUserInput_StripsControlBytesAndANSI is the regression test for
+// F-1 (deep-review-2026-06-14 contrarian re-review). The prior strings.Replacer
+// only stripped CR/LF/TAB and the Unicode separators, so ESC (0x1B), backspace,
+// NUL, BEL, VT, FF and DEL passed through unescaped — letting an attacker inject
+// ANSI terminal-escape sequences (clear screen / recolor) or overwrite already
+// logged text via backspace. Every byte below must be neutralized to a space
+// while ordinary printable and non-control multi-byte runes are preserved.
+func TestEscapeUserInput_StripsControlBytesAndANSI(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"escape_clear_screen", "a\x1b[2Jb", "a [2Jb"},
+		{"ansi_color_sequence", "\x1b[31mRED\x1b[0m", " [31mRED [0m"},
+		{"osc_set_title", "x\x1b]2;evil\x07y", "x ]2;evil y"},
+		{"backspace_overwrite", "admin\x08\x08\x08\x08\x08guest", "admin     guest"},
+		{"null_byte", "a\x00b", "a b"},
+		{"bell", "a\x07b", "a b"},
+		{"vertical_tab", "a\x0bb", "a b"},
+		{"form_feed", "a\x0cb", "a b"},
+		{"del", "a\x7fb", "a b"},
+		{"printable_url_preserved", "https://sns.us-east-1.amazonaws.com/x?a=b", "https://sns.us-east-1.amazonaws.com/x?a=b"},
+		{"ascii_space_preserved", "a b c", "a b c"},
+		{"non_control_unicode_preserved", "café-日本", "café-日本"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := escapeUserInput(tc.input)
+			if got != tc.want {
+				t.Errorf("escapeUserInput(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+			if strings.ContainsRune(got, '\x1b') {
+				t.Errorf("escapeUserInput(%q) left a raw ESC byte in output: %q", tc.input, got)
+			}
+		})
+	}
+}
+
+// TestLogInjection_ServerUrl_Escaped is the regression test for F-3
+// (deep-review-2026-06-14). The DynamoDB-sourced serverUrl is relayed into the
+// /snsrouter 'notification' log lines; it is now wrapped with escapeUserInput so
+// a malformed/compromised data-store value cannot inject ANSI escapes or forged
+// log lines into operator logs.
+func TestLogInjection_ServerUrl_Escaped(t *testing.T) {
+	maliciousServerURL := "http://10.0.0.5:8080\x1b[2J\n2026-06-14 CRITICAL: forged entry"
+
+	var buf bytes.Buffer
+	origOutput := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(origOutput) })
+
+	// Same shape as the /snsrouter 'notification' relay log site, with the fix.
+	log.Println("/snsrouter 'notification' Relaying SNS Data To Notifier Server Endpoint '" + escapeUserInput(maliciousServerURL) + "': {}")
+
+	output := buf.String()
+	if strings.ContainsRune(output, '\x1b') {
+		t.Errorf("log output contains raw ESC byte from serverUrl:\n%q", output)
+	}
+	if strings.Contains(output, "\n2026-06-14 CRITICAL") {
+		t.Errorf("log output contains forged newline-injected entry:\n%q", output)
+	}
+}
+
 // TestLogInjection_InstanceIdEscaped_Regression verifies that logging an
 // instanceId containing CR/LF through the escapeUserInput wrapper produces
 // output with NO raw control characters. This is the regression test for


### PR DESCRIPTION
## Summary

Hardens log-injection defenses found by an independent **blind contrarian security re-review** (2026-06-14) of master `4696861` — a fresh adversarial pass that did not read the prior review's findings. It returned **MINOR-ISSUES, no P0/P1 blocker**, and independently rediscovered the three already-documented deferrals (replay protection, cert-chain hard-reject, day-granularity token window). The two genuinely-new items it surfaced are fixed here; both are completeness gaps in the existing `escapeUserInput` control.

## F-1 (P2 — verified, unauthenticated-reachable)

`escapeUserInput` only stripped CR/LF/TAB + the Unicode line/paragraph separators, so **ESC (0x1B), backspace, NUL, BEL, VT, FF, DEL passed through unescaped**. An attacker who POSTs to `/snsrouter` can place ANSI terminal-escape sequences (clear screen / recolor) or backspace-overwrite chars in an SNS `MessageId`; that value is logged via `escapeUserInput` on the **signature-FAILED** path (`notifiergateway.go` ~673), so **no valid SNS signature is required** to inject into operator logs/terminals.

**Fix:** rewrite `escapeUserInput` to map every `unicode.IsControl` rune (C0 `0x00–0x1F`, DEL `0x7F`, C1 incl. NEL `U+0085`) **plus** `U+2028`/`U+2029` (Zl/Zp — `IsControl` does not cover them) to a space, replacing the incomplete `strings.Replacer`. This strengthens **every** existing `escapeUserInput` call site, not just the new ones.

## F-3 (P3 — defense-in-depth)

The DynamoDB-sourced `serverUrl` was logged raw at the 5 `/snsrouter` `'notification'` relay sites. Now wrapped with `escapeUserInput` so a malformed/compromised data-store value cannot inject into logs.

## Tests
- `TestEscapeUserInput_StripsControlBytesAndANSI` — ESC/BS/NUL/BEL/VT/FF/DEL neutralized; printable, ASCII space, and non-control multi-byte runes preserved; asserts no raw ESC survives.
- `TestLogInjection_ServerUrl_Escaped` — buffer-capture regression for the relay log site.
- All pre-existing escape/log-injection tests unchanged and still pass (zero regressions).

## Verification
- `gofmt -l` clean · `go vet` clean · `go build ./...` clean
- `go test ./notifiergateway/ -short` green; `-race` green
- Full `go test ./... -short` = **27 ok / 0 FAIL**
- `golangci-lint` issue delta vs master = **0** (57 → 57; pre-existing baseline untouched)

## Not included (operator decisions — documented deferrals, independently re-confirmed by this review)
- SNS replay protection (timestamp recency + MessageId dedup) at the gateway
- Cert-chain verification WARN-and-proceed → hard-reject (pending live-AWS confirmation)
- Health/callerid auth-token window narrowing (currently UTC-day granularity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)