### PR TITLE
perf(client): gate per-call circuit-breaker trace logging behind DebugCircuitBreaker (default off)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -368,6 +368,15 @@ type Client struct {
 	// indicate if after dial, client will wait for target service health probe success before continuing to allow rpc
 	WaitForServerReady bool
 
+	// DebugCircuitBreaker gates the per-call circuit-breaker trace logging
+	// (the INFO "In - ... Handler", "Run ... Action", cache create/hit lines)
+	// emitted on every unary/stream RPC by the CB handlers. It defaults to
+	// false (silent) because those lines are on the hot path: a single
+	// starved task produced ~380K INFO lines in 20 minutes, burning CPU.
+	// Set true only for transient debugging. ERROR/WARN logging is never
+	// gated by this flag and remains unconditional.
+	DebugCircuitBreaker bool
+
 	// P2-14: ConnectionCloseDelay controls how long setConnection waits
 	// before closing a replaced gRPC connection, allowing in-flight RPCs
 	// to drain. Zero or negative falls back to the 100ms default
@@ -1232,6 +1241,24 @@ func (c *Client) logWarn(msg string) {
 	} else {
 		log.Printf("%s", msg)
 	}
+}
+
+// cbTraceSink is the indirection cbTrace dispatches to once the
+// DebugCircuitBreaker gate passes. It defaults to logLine (the real INFO
+// sink); tests swap it to observe the gating decision deterministically,
+// since logLine's underlying ZapLog sink is a no-op when disabled and
+// otherwise writes to its own console and is not unit-capturable.
+var cbTraceSink = (*Client).logLine
+
+// cbTrace gates per-call circuit-breaker trace logging behind
+// DebugCircuitBreaker. It is the single seam through which every hot-path
+// CB INFO line flows, so the ~380K-lines-in-20-min incident is silenced
+// by default (zero-value flag) without touching ERROR/WARN visibility.
+func (c *Client) cbTrace(msg string) {
+	if c == nil || !c.DebugCircuitBreaker {
+		return
+	}
+	cbTraceSink(c, msg)
 }
 
 // PreloadConfigData will load the config data before Dial()
@@ -3149,12 +3176,12 @@ func (c *Client) unaryCircuitBreakerHandler(ctx context.Context, method string, 
 	// use a literal-string fast-path so `%` in messages can't be misread as
 	// format specifiers.
 
-	c.logLine("In - Unary Circuit Breaker Handler: " + method)
+	c.cbTrace("In - Unary Circuit Breaker Handler: " + method)
 
 	cb := c.getCircuitBreaker(method)
 
 	if cb == nil {
-		c.logLine("... Creating Circuit Breaker for: " + method)
+		c.cbTrace("... Creating Circuit Breaker for: " + method)
 
 		z := &data.ZapLog{
 			DisableLogger:   false,
@@ -3181,20 +3208,20 @@ func (c *Client) unaryCircuitBreakerHandler(ctx context.Context, method string, 
 
 		c.setCircuitBreaker(method, cb)
 
-		c.logLine("... Circuit Breaker Created for: " + method)
+		c.cbTrace("... Circuit Breaker Created for: " + method)
 	} else {
-		c.logLine("... Using Cached Circuit Breaker Command: " + method)
+		c.cbTrace("... Using Cached Circuit Breaker Command: " + method)
 	}
 
 	_, gerr := cb.Exec(true, func(dataIn interface{}, ctx1 ...context.Context) (dataOut interface{}, err error) {
-		c.logLine("Run Circuit Breaker Action for: " + method + "...")
+		c.cbTrace("Run Circuit Breaker Action for: " + method + "...")
 
 		err = invoker(ctx, method, req, reply, cc, opts...)
 
 		if err != nil {
 			c.logErr("!!! Circuit Breaker Action for " + method + " Failed: " + err.Error() + " !!!")
 		} else {
-			c.logLine("... Circuit Breaker Action for " + method + " Invoked")
+			c.cbTrace("... Circuit Breaker Action for " + method + " Invoked")
 		}
 		return nil, err
 
@@ -3240,12 +3267,12 @@ func (c *Client) streamCircuitBreakerHandler(
 	// unaryCircuitBreakerHandler — closures replaced with *Client methods
 	// to eliminate per-stream allocations (~600-900 B + 8-12 allocs).
 
-	c.logLine("In - Stream Circuit Breaker Handler: " + method)
+	c.cbTrace("In - Stream Circuit Breaker Handler: " + method)
 
 	cb := c.getCircuitBreaker(method)
 
 	if cb == nil {
-		c.logLine("... Creating Circuit Breaker for: " + method)
+		c.cbTrace("... Creating Circuit Breaker for: " + method)
 
 		z := &data.ZapLog{
 			DisableLogger:   false,
@@ -3273,20 +3300,20 @@ func (c *Client) streamCircuitBreakerHandler(
 
 		c.setCircuitBreaker(method, cb)
 
-		c.logLine("... Circuit Breaker Created for: " + method)
+		c.cbTrace("... Circuit Breaker Created for: " + method)
 	} else {
-		c.logLine("... Using Cached Circuit Breaker Command: " + method)
+		c.cbTrace("... Using Cached Circuit Breaker Command: " + method)
 	}
 
 	gres, gerr := cb.Exec(true, func(dataIn interface{}, ctx1 ...context.Context) (dataOut interface{}, err error) {
-		c.logLine("Run Circuit Breaker Action for: " + method + "...")
+		c.cbTrace("Run Circuit Breaker Action for: " + method + "...")
 
 		dataOut, err = streamer(ctx, desc, cc, method, opts...)
 
 		if err != nil {
 			c.logErr("!!! Circuit Breaker Action for " + method + " Failed: " + err.Error() + " !!!")
 		} else {
-			c.logLine("... Circuit Breaker Action for " + method + " Invoked")
+			c.cbTrace("... Circuit Breaker Action for " + method + " Invoked")
 		}
 		return dataOut, err
 	}, func(dataIn interface{}, errIn error, ctx1 ...context.Context) (dataOut interface{}, err error) {

--- a/client/client_cbtrace_test.go
+++ b/client/client_cbtrace_test.go
@@ -1,0 +1,85 @@
+package client
+
+/*
+ * Copyright 2020-2023 Aldelo, LP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import (
+	"testing"
+)
+
+// CB-TRACE gating tests.
+//
+// A prod incident traced ~380K circuit-breaker INFO lines in 20 minutes
+// from the per-call CB handlers (hot path). cbTrace gates those trace
+// lines behind Client.DebugCircuitBreaker (default false = silent) while
+// ERROR logging stays unconditional. These tests pin the single gating
+// seam: cbTrace must route to logLine ONLY when the flag is enabled.
+//
+// logLine ultimately writes through ZapLog (or the std log fallback),
+// neither of which is deterministically capturable in a unit context
+// (ZapLog is a no-op when DisableLogger=true, otherwise writes to its own
+// console sink). To assert the gating boolean deterministically we swap
+// the cbTrace sink for a counter; the production default routes to the
+// real logLine, so behavior is unchanged outside the test.
+
+func TestCB_TraceGatedOffByDefault(t *testing.T) {
+	c := &Client{} // zero value: DebugCircuitBreaker == false
+
+	calls := 0
+	orig := cbTraceSink
+	cbTraceSink = func(_ *Client, _ string) { calls++ }
+	defer func() { cbTraceSink = orig }()
+
+	c.cbTrace("In - Unary Circuit Breaker Handler: /svc/Method")
+
+	if calls != 0 {
+		t.Fatalf("cbTrace must NOT emit when DebugCircuitBreaker is false; got %d sink calls", calls)
+	}
+}
+
+func TestCB_TraceEmitsWhenDebugEnabled(t *testing.T) {
+	c := &Client{DebugCircuitBreaker: true}
+
+	calls := 0
+	var lastMsg string
+	orig := cbTraceSink
+	cbTraceSink = func(_ *Client, msg string) {
+		calls++
+		lastMsg = msg
+	}
+	defer func() { cbTraceSink = orig }()
+
+	c.cbTrace("Run Circuit Breaker Action for: /svc/Method...")
+
+	if calls != 1 {
+		t.Fatalf("cbTrace must emit exactly once when DebugCircuitBreaker is true; got %d sink calls", calls)
+	}
+	if lastMsg != "Run Circuit Breaker Action for: /svc/Method..." {
+		t.Fatalf("cbTrace forwarded wrong message: %q", lastMsg)
+	}
+}
+
+// TestCB_TraceNilClientIsSafe pins that the gate tolerates a nil receiver
+// (the CB handlers guard nil, but cbTrace must not be the thing that panics).
+func TestCB_TraceNilClientIsSafe(t *testing.T) {
+	var c *Client // nil
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("cbTrace on nil client must not panic; got %v", r)
+		}
+	}()
+	c.cbTrace("should be a no-op on nil client")
+}


### PR DESCRIPTION
## Why

A production incident on a downstream consumer (`epay-rest-tms-service`, `POST /transaction/list`) was root-caused to **Go-scheduler starvation on a 0.5-vCPU task**. One contributor was log-CPU amplification: the per-call circuit-breaker handlers emit INFO trace lines on **every** unary/stream RPC, and CloudWatch Logs showed **~380,000 circuit-breaker INFO lines in a ~20-minute window**. That logging burns scheduler time on an already-starved task.

## What

- Add an opt-in `Client.DebugCircuitBreaker bool` (zero-value `false` = silent).
- Route all **12** hot/cold-path circuit-breaker trace lines (6 in `unaryCircuitBreakerHandler`, 6 in `streamCircuitBreakerHandler`) through a single `c.cbTrace()` seam that emits only when the flag is set.
- **ERROR/WARN logging is unchanged and remains unconditional** — only INFO trace noise is gated.
- The **hystrix process-global logger is untouched**: gating lives at the `Client` level to avoid a shared-state hazard.

## Behavioral impact

Default-off changes prod CB trace log volume from ~380K lines/20min → ~0. Consumers that want the old verbose behavior set `DebugCircuitBreaker = true`. No exported signature changed.

## Verification (in this PR)

- `go build ./...` → exit 0
- `go vet ./client/` → exit 0
- New unit tests (`TestCB_TraceGatedOffByDefault`, `TestCB_TraceEmitsWhenDebugEnabled`, `TestCB_TraceNilClientIsSafe`) + the existing unit subset → `ok`
- `gofmt` clean
- (Pre-existing `TestClient_Dial` requires a live gRPC/SD endpoint and is unaffected by this change.)

## ⚠️ Do not merge without owning-team review

This is a behavioral change to log output on a shared payment-infra library. Please review the default-off decision against any operational dashboards/alerts that consume these INFO lines before merging/tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
