### PR TITLE
feat(client): client-side dead-endpoint failover — configurable health check, opt-in retry policy, evict-on-dial-failure (A2 plan Options A+B)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1134,6 +1134,14 @@ func (c *Client) buildDialOptions(loadBalancerPolicy string) (opts []grpc.DialOp
 		unaryInts = append(unaryInts, tracer.TracerUnaryClientInterceptor(cfg.Target.AppName+"-Client"))
 	}
 
+	if cfg.Grpc.EvictOnDialFailureEnabled {
+		logPrintf("Setup Unary Dead-Endpoint Failover Interceptor")
+		// Appended LAST so it is the innermost interceptor: its invoker is the raw RPC (so the
+		// retry re-picks a round_robin subconn), and any circuit breaker wrapping it observes the
+		// final post-failover outcome rather than the first dial error.
+		unaryInts = append(unaryInts, c.unaryDeadEndpointFailoverHandler)
+	}
+
 	count := len(unaryInts)
 
 	if count == 1 {
@@ -3263,6 +3271,126 @@ func (c *Client) setApiDiscoveredIpPorts(cacheExpires time.Time, serviceName str
 	c.setEndpoints(pruneExpiredEndpoints(cacheGetLiveServiceEndpoints(key, version, false)))
 
 	return nil
+}
+
+// parseDialFailureHostPort extracts the "host:port" from a gRPC dial-failure error string.
+//
+// gRPC wraps a connection-establishment failure as:
+//
+//	"... transport: error while dialing: dial tcp <host>:<port>: <reason>"
+//
+// (host may be an IPv4, a bracketed IPv6 literal, or a name). Only that specific "dial tcp"
+// form is matched, so an application-level error that merely happens to contain a "host:port"
+// substring cannot be misparsed as a dead endpoint. Returns ok=false when the string is not a
+// dial failure or the host/port cannot be recovered cleanly.
+func parseDialFailureHostPort(errMsg string) (host string, port uint, ok bool) {
+	const marker = "dial tcp "
+	idx := strings.Index(errMsg, marker)
+	if idx < 0 {
+		return "", 0, false
+	}
+
+	// Also require the "error while dialing" phrase so we only act on true dial failures.
+	if !strings.Contains(errMsg, "error while dialing") {
+		return "", 0, false
+	}
+
+	rest := errMsg[idx+len(marker):]
+
+	// The address runs up to the next ": " that precedes the reason text. Take the first colon
+	// that is followed by a space — that delimits "<addr>: <reason>". Bracketed IPv6 keeps its
+	// own colons inside [...], and a port is always numeric with no space, so this is safe.
+	end := strings.Index(rest, ": ")
+	if end < 0 {
+		return "", 0, false
+	}
+	addr := strings.TrimSpace(rest[:end])
+	if addr == "" {
+		return "", 0, false
+	}
+
+	h, p, splitErr := net.SplitHostPort(addr)
+	if splitErr != nil || h == "" || p == "" {
+		return "", 0, false
+	}
+
+	portNum, convErr := strconv.Atoi(p)
+	if convErr != nil || portNum < 1 || portNum > 65535 {
+		return "", 0, false
+	}
+
+	return h, uint(portNum), true
+}
+
+// evictEndpointAndUpdateResolver purges a single dead host:port from the discovery cache and
+// pushes the trimmed endpoint set to the round_robin resolver. It mirrors the eviction that the
+// SNS ServiceHostOfflineHandler performs (see the ServiceHostOfflineHandler wiring in
+// configureNotifierHandlers), but is driven by an observed dial failure rather than an SNS offline event —
+// so it works even when the notifier has silently died. Returns true if the resolver was updated.
+func (c *Client) evictEndpointAndUpdateResolver(host string, port uint) bool {
+	if c == nil || c.closed.Load() {
+		return false
+	}
+	cfg := c.getConfig()
+	if cfg == nil {
+		return false
+	}
+
+	svcKey := strings.ToLower(cfg.Target.ServiceName + "." + cfg.Target.NamespaceName)
+	cachePurgeServiceEndpointByHostAndPort(svcKey, host, port)
+	c.setEndpoints(cacheGetLiveServiceEndpoints(svcKey, cfg.Target.InstanceVersion, true))
+	if resolverErr := c.UpdateLoadBalanceResolver(); resolverErr != nil {
+		c.logWarn("evictEndpointAndUpdateResolver: UpdateLoadBalanceResolver failed after purging " +
+			host + ":" + util.UintToStr(port) + ": " + resolverErr.Error())
+		return false
+	}
+	return true
+}
+
+// unaryDeadEndpointFailoverHandler is a unary client interceptor that implements Option B of the
+// A2 fix plan: on a dial failure to a specific endpoint, evict just that endpoint and retry the
+// RPC once against the trimmed round_robin set. It is only wired when EvictOnDialFailureEnabled
+// is set; when off, it is never added to the interceptor chain (zero overhead / no behavior
+// change). Retry is bounded to exactly one extra attempt and only ever fires on a dial failure —
+// where the connection was never established, so the original request provably never reached a
+// server and re-sending it is safe regardless of method idempotency.
+func (c *Client) unaryDeadEndpointFailoverHandler(ctx context.Context, method string, req interface{}, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	if c == nil {
+		return fmt.Errorf("Client Object Nil")
+	}
+	if c.closed.Load() {
+		return status.Error(codes.Unavailable, "client is closed")
+	}
+
+	err := invoker(ctx, method, req, reply, cc, opts...)
+	if err == nil {
+		return nil
+	}
+
+	// Snapshot config once; bail to the plain error if the feature is off or the setup can't
+	// support failover (direct connect / no load balancer => no alternate endpoints).
+	cfg := c.getConfig()
+	if cfg == nil || !cfg.Grpc.EvictOnDialFailureEnabled ||
+		!cfg.Grpc.UseLoadBalancer || cfg.Target.ServiceDiscoveryType == "direct" {
+		return err
+	}
+
+	host, port, ok := parseDialFailureHostPort(err.Error())
+	if !ok {
+		return err
+	}
+
+	c.logWarn("unaryDeadEndpointFailoverHandler: dial failure on " + host + ":" + util.UintToStr(port) +
+		" for " + method + " — evicting endpoint and retrying once")
+
+	if !c.evictEndpointAndUpdateResolver(host, port) {
+		// Could not evict/update (e.g. no endpoints left); surface the original error.
+		return err
+	}
+
+	// Retry exactly once against the trimmed endpoint set. round_robin now excludes the dead
+	// endpoint, so this attempt targets a remaining (hopefully live) endpoint.
+	return invoker(ctx, method, req, reply, cc, opts...)
 }
 
 func (c *Client) unaryCircuitBreakerHandler(ctx context.Context, method string, req interface{}, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {

--- a/client/client.go
+++ b/client/client.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -924,6 +925,22 @@ func (c *Client) readConfig() error {
 	return nil
 }
 
+// healthCheckServiceConfigFragment builds the "healthCheckConfig" fragment of a gRPC
+// service config (no outer braces — the caller wraps the assembled fragments in `{...}`).
+// serviceName is the grpc.health.v1 service the client watches; it is JSON-escaped so an
+// operator-supplied value cannot break the service config JSON (an invalid service config
+// is silently ignored by gRPC, which would disable health checking without warning).
+// An empty serviceName reproduces the historical `{"serviceName":""}` (watch the default
+// unnamed health service).
+func healthCheckServiceConfigFragment(serviceName string) string {
+	nameJSON, err := json.Marshal(serviceName)
+	if err != nil {
+		// serviceName is a plain string; Marshal cannot fail. Fall back to the empty name.
+		nameJSON = []byte(`""`)
+	}
+	return `"healthCheckConfig":{"serviceName":` + string(nameJSON) + `}`
+}
+
 // buildDialOptions returns slice of dial options built from client struct fields
 func (c *Client) buildDialOptions(loadBalancerPolicy string) (opts []grpc.DialOption, err error) {
 	if c == nil {
@@ -1015,7 +1032,10 @@ func (c *Client) buildDialOptions(loadBalancerPolicy string) (opts []grpc.DialOp
 			defSvrConf += ", "
 		}
 
-		defSvrConf += `"healthCheckConfig":{"serviceName":""}`
+		// Watch the configured grpc.health.v1 service name (empty => the default unnamed
+		// service, preserving prior behavior). A non-empty name lets the round_robin balancer
+		// eject subconns whose health goes NOT_SERVING — client-side auto-skip of a dead instance.
+		defSvrConf += healthCheckServiceConfigFragment(cfg.Grpc.HealthCheckServiceName)
 	}
 
 	if util.LenTrim(defSvrConf) > 0 {

--- a/client/client.go
+++ b/client/client.go
@@ -941,6 +941,33 @@ func healthCheckServiceConfigFragment(serviceName string) string {
 	return `"healthCheckConfig":{"serviceName":` + string(nameJSON) + `}`
 }
 
+// retryPolicyServiceConfigFragment builds the "methodConfig" fragment of a gRPC service
+// config (no outer braces — the caller wraps the assembled fragments in `{...}`). It applies
+// a UNAVAILABLE-only retryPolicy to ALL methods (empty name/method selector). Combined with a
+// round_robin balancer, a retry re-picks the next subconn, so a request that lands on a dead
+// endpoint transparently fails over to a live one instead of surfacing the dial error.
+//
+// maxAttempts is clamped to gRPC's valid range [2,5] (total attempts incl. the original).
+// Only UNAVAILABLE is retried — dial failures / connection-refused surface as UNAVAILABLE,
+// while application-level errors (e.g. INVALID_ARGUMENT, NOT_FOUND) are NOT retried.
+func retryPolicyServiceConfigFragment(maxAttempts uint) string {
+	if maxAttempts < 2 {
+		maxAttempts = 2
+	}
+	if maxAttempts > 5 {
+		maxAttempts = 5
+	}
+	return `"methodConfig":[{` +
+		`"name":[{}],` +
+		`"retryPolicy":{` +
+		`"maxAttempts":` + strconv.FormatUint(uint64(maxAttempts), 10) + `,` +
+		`"initialBackoff":"0.1s",` +
+		`"maxBackoff":"1s",` +
+		`"backoffMultiplier":2.0,` +
+		`"retryableStatusCodes":["UNAVAILABLE"]` +
+		`}}]`
+}
+
 // buildDialOptions returns slice of dial options built from client struct fields
 func (c *Client) buildDialOptions(loadBalancerPolicy string) (opts []grpc.DialOption, err error) {
 	if c == nil {
@@ -1038,6 +1065,16 @@ func (c *Client) buildDialOptions(loadBalancerPolicy string) (opts []grpc.DialOp
 		defSvrConf += healthCheckServiceConfigFragment(cfg.Grpc.HealthCheckServiceName)
 	}
 
+	if cfg.Grpc.RetryPolicyEnabled {
+		if util.LenTrim(defSvrConf) > 0 {
+			defSvrConf += ", "
+		}
+
+		// Retry UNAVAILABLE so a dial failure onto a dead endpoint transparently fails over to
+		// the next round_robin subconn instead of returning the error to the caller.
+		defSvrConf += retryPolicyServiceConfigFragment(cfg.Grpc.RetryPolicyMaxAttempts)
+	}
+
 	if util.LenTrim(defSvrConf) > 0 {
 		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{%s}`, defSvrConf)))
 	}
@@ -1075,8 +1112,12 @@ func (c *Client) buildDialOptions(loadBalancerPolicy string) (opts []grpc.DialOp
 		opts = append(opts, grpc.WithWriteBufferSize(int(cfg.Grpc.WriteBufferSize)))
 	}
 
-	// turn off retry when retry default is enabled in the future framework versions
-	opts = append(opts, grpc.WithDisableRetry())
+	// Turn off retry by default. When RetryPolicyEnabled is set, we intentionally leave gRPC
+	// retry ON so the service-config retryPolicy above can transparently fail over UNAVAILABLE
+	// RPCs onto the next round_robin subconn; disabling retry here would neutralize that policy.
+	if !cfg.Grpc.RetryPolicyEnabled {
+		opts = append(opts, grpc.WithDisableRetry())
+	}
 
 	// Build interceptor chains from a fresh local slice to avoid duplicate appends across re-dials.
 	unaryInts := append([]grpc.UnaryClientInterceptor{}, c.UnaryClientInterceptors...)

--- a/client/client_failover_test.go
+++ b/client/client_failover_test.go
@@ -1,0 +1,201 @@
+package client
+
+/*
+ * Copyright 2020-2026 Aldelo, LP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc"
+)
+
+// ---------------------------------------------------------------------------
+// parseDialFailureHostPort — pure parser (the plan flags mis-parsing as the key risk)
+// ---------------------------------------------------------------------------
+
+func TestParseDialFailureHostPort_RealGrpcMessages(t *testing.T) {
+	cases := []struct {
+		name     string
+		errMsg   string
+		wantHost string
+		wantPort uint
+	}{
+		{
+			name:     "connection refused ipv4",
+			errMsg:   `rpc error: code = Unavailable desc = connection error: desc = "transport: error while dialing: dial tcp 10.2.100.204:37387: connect: connection refused"`,
+			wantHost: "10.2.100.204",
+			wantPort: 37387,
+		},
+		{
+			name:     "i/o timeout ipv4",
+			errMsg:   `transport: error while dialing: dial tcp 10.2.136.233:35965: i/o timeout`,
+			wantHost: "10.2.136.233",
+			wantPort: 35965,
+		},
+		{
+			name:     "no route to host ipv4",
+			errMsg:   `transport: error while dialing: dial tcp 10.2.129.150:37065: connect: no route to host`,
+			wantHost: "10.2.129.150",
+			wantPort: 37065,
+		},
+		{
+			name:     "connection timed out ipv4",
+			errMsg:   `transport: error while dialing: dial tcp 10.2.116.228:33141: connect: connection timed out`,
+			wantHost: "10.2.116.228",
+			wantPort: 33141,
+		},
+		{
+			name:     "ipv6 bracketed",
+			errMsg:   `transport: error while dialing: dial tcp [2001:db8::1]:8443: connect: connection refused`,
+			wantHost: "2001:db8::1",
+			wantPort: 8443,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			host, port, ok := parseDialFailureHostPort(tc.errMsg)
+			if !ok {
+				t.Fatalf("expected ok=true for %q", tc.errMsg)
+			}
+			if host != tc.wantHost || port != tc.wantPort {
+				t.Fatalf("parsed %s:%d, want %s:%d", host, port, tc.wantHost, tc.wantPort)
+			}
+		})
+	}
+}
+
+func TestParseDialFailureHostPort_RejectsNonDialErrors(t *testing.T) {
+	// None of these are dial failures; the parser must NOT extract an endpoint (so an
+	// app-level error that merely contains a host:port cannot be mistaken for a dead endpoint).
+	cases := []string{
+		``,
+		`rpc error: code = NotFound desc = merchant 10.2.0.5:80 not found`, // host:port in payload, not a dial failure
+		`rpc error: code = InvalidArgument desc = bad request`,
+		`hystrix: circuit open`,
+		`context deadline exceeded`,
+		`transport: error while dialing: dial tcp: missing port`,          // no host:port
+		`transport: error while dialing: dial tcp 10.2.0.5: no colon`,     // no port
+		`transport: error while dialing: dial tcp 10.2.0.5:0: bad port`,   // port 0 invalid
+		`transport: error while dialing: dial tcp 10.2.0.5:99999: bad`,    // port out of range
+		`some error mentioning dial tcp 10.2.0.5:80: but not a dial fail`, // lacks "error while dialing"
+	}
+	for _, msg := range cases {
+		if host, port, ok := parseDialFailureHostPort(msg); ok {
+			t.Errorf("expected ok=false for %q, got %s:%d", msg, host, port)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// unaryDeadEndpointFailoverHandler — gating behavior (no live conn required)
+// ---------------------------------------------------------------------------
+
+// countingInvoker returns a UnaryInvoker that records how many times it was called and
+// returns the given error on every call.
+func countingInvoker(calls *int, retErr error) grpc.UnaryInvoker {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		*calls++
+		return retErr
+	}
+}
+
+func failoverTestClient(enabled bool) *Client {
+	c := &Client{}
+	c._config.Store(&config{
+		Target: targetData{
+			ServiceName:          "dal-config-read-get-service",
+			NamespaceName:        "live.aldelo.nae",
+			ServiceDiscoveryType: "api",
+		},
+		Grpc: grpcData{
+			UseLoadBalancer:           true,
+			EvictOnDialFailureEnabled: enabled,
+		},
+	})
+	return c
+}
+
+func TestUnaryDeadEndpointFailover_SuccessPassesThroughNoRetry(t *testing.T) {
+	c := failoverTestClient(true)
+	calls := 0
+	err := c.unaryDeadEndpointFailoverHandler(context.Background(), "/svc/M", nil, nil, nil, countingInvoker(&calls, nil))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 invoke on success, got %d", calls)
+	}
+}
+
+func TestUnaryDeadEndpointFailover_DisabledDoesNotRetry(t *testing.T) {
+	c := failoverTestClient(false) // feature off
+	calls := 0
+	dialErr := errors.New(`transport: error while dialing: dial tcp 10.2.100.204:37387: connect: connection refused`)
+	err := c.unaryDeadEndpointFailoverHandler(context.Background(), "/svc/M", nil, nil, nil, countingInvoker(&calls, dialErr))
+	if err == nil {
+		t.Fatalf("expected the dial error to pass through")
+	}
+	if calls != 1 {
+		t.Fatalf("feature disabled: expected exactly 1 invoke (no retry), got %d", calls)
+	}
+}
+
+func TestUnaryDeadEndpointFailover_NonDialErrorDoesNotRetry(t *testing.T) {
+	c := failoverTestClient(true)
+	calls := 0
+	appErr := errors.New(`rpc error: code = NotFound desc = merchant not found`)
+	err := c.unaryDeadEndpointFailoverHandler(context.Background(), "/svc/M", nil, nil, nil, countingInvoker(&calls, appErr))
+	if err == nil {
+		t.Fatalf("expected the app error to pass through")
+	}
+	if calls != 1 {
+		t.Fatalf("non-dial error: expected exactly 1 invoke (no retry), got %d", calls)
+	}
+}
+
+func TestUnaryDeadEndpointFailover_DirectConnectDoesNotRetry(t *testing.T) {
+	c := failoverTestClient(true)
+	// direct discovery has no alternate endpoints to fail over to => must not retry.
+	cfg := c.getConfig()
+	cfg.Target.ServiceDiscoveryType = "direct"
+	c._config.Store(cfg)
+
+	calls := 0
+	dialErr := errors.New(`transport: error while dialing: dial tcp 10.2.100.204:37387: connect: connection refused`)
+	err := c.unaryDeadEndpointFailoverHandler(context.Background(), "/svc/M", nil, nil, nil, countingInvoker(&calls, dialErr))
+	if err == nil {
+		t.Fatalf("expected the dial error to pass through")
+	}
+	if calls != 1 {
+		t.Fatalf("direct connect: expected exactly 1 invoke (no retry), got %d", calls)
+	}
+}
+
+func TestUnaryDeadEndpointFailover_ClosedClientReturnsUnavailable(t *testing.T) {
+	c := failoverTestClient(true)
+	c.closed.Store(true)
+	calls := 0
+	err := c.unaryDeadEndpointFailoverHandler(context.Background(), "/svc/M", nil, nil, nil, countingInvoker(&calls, nil))
+	if err == nil {
+		t.Fatalf("expected an error when client is closed")
+	}
+	if calls != 0 {
+		t.Fatalf("closed client: invoker must not be called, got %d calls", calls)
+	}
+}

--- a/client/client_healthcheck_test.go
+++ b/client/client_healthcheck_test.go
@@ -1,0 +1,99 @@
+package client
+
+/*
+ * Copyright 2020-2026 Aldelo, LP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The health-check fragment feeds gRPC's WithDefaultServiceConfig. gRPC SILENTLY ignores an
+// invalid service config (health checking then never activates), so the fragment must always
+// assemble into valid JSON — even when an operator supplies a service name containing quotes
+// or backslashes. These tests lock in both the empty-name (historical) shape and JSON safety.
+
+func TestHealthCheckServiceConfigFragment_EmptyNamePreservesLegacyShape(t *testing.T) {
+	got := healthCheckServiceConfigFragment("")
+	want := `"healthCheckConfig":{"serviceName":""}`
+	if got != want {
+		t.Fatalf("empty name fragment = %q, want %q (must match pre-change behavior)", got, want)
+	}
+}
+
+func TestHealthCheckServiceConfigFragment_NamedService(t *testing.T) {
+	got := healthCheckServiceConfigFragment("dal-config-read-get")
+	want := `"healthCheckConfig":{"serviceName":"dal-config-read-get"}`
+	if got != want {
+		t.Fatalf("named fragment = %q, want %q", got, want)
+	}
+}
+
+// The fragment is wrapped by the caller as `{ <lb>, <fragment> }`. Verify that wrapping
+// always yields parseable JSON with the expected serviceName, including hostile inputs.
+func TestHealthCheckServiceConfigFragment_AlwaysValidJSON(t *testing.T) {
+	names := []string{
+		"",
+		"simple",
+		`has"quote`,
+		`has\backslash`,
+		"unicode-☃",
+		"tab\tinside",
+	}
+
+	for _, name := range names {
+		fragment := healthCheckServiceConfigFragment(name)
+		wrapped := "{" + fragment + "}"
+
+		var parsed struct {
+			HealthCheckConfig struct {
+				ServiceName string `json:"serviceName"`
+			} `json:"healthCheckConfig"`
+		}
+		if err := json.Unmarshal([]byte(wrapped), &parsed); err != nil {
+			t.Fatalf("wrapped service config for name %q is not valid JSON: %v (wrapped=%q)", name, err, wrapped)
+		}
+		if parsed.HealthCheckConfig.ServiceName != name {
+			t.Fatalf("round-tripped serviceName = %q, want %q", parsed.HealthCheckConfig.ServiceName, name)
+		}
+	}
+}
+
+// Combined with the round-robin LB fragment (the real dial-time assembly), the full service
+// config must still be valid JSON so BOTH load balancing and health checking take effect.
+func TestHealthCheckServiceConfigFragment_ComposesWithLoadBalancerPolicy(t *testing.T) {
+	lb := `"loadBalancingConfig":[{"round_robin":{}}]`
+	full := "{" + lb + ", " + healthCheckServiceConfigFragment("dal-config-read-get") + "}"
+
+	var parsed struct {
+		LoadBalancingConfig []map[string]json.RawMessage `json:"loadBalancingConfig"`
+		HealthCheckConfig   struct {
+			ServiceName string `json:"serviceName"`
+		} `json:"healthCheckConfig"`
+	}
+	if err := json.Unmarshal([]byte(full), &parsed); err != nil {
+		t.Fatalf("full service config is not valid JSON: %v (full=%q)", err, full)
+	}
+	if len(parsed.LoadBalancingConfig) != 1 {
+		t.Fatalf("expected 1 loadBalancingConfig entry, got %d", len(parsed.LoadBalancingConfig))
+	}
+	if _, ok := parsed.LoadBalancingConfig[0]["round_robin"]; !ok {
+		t.Fatalf("expected round_robin policy in loadBalancingConfig")
+	}
+	if parsed.HealthCheckConfig.ServiceName != "dal-config-read-get" {
+		t.Fatalf("serviceName = %q, want dal-config-read-get", parsed.HealthCheckConfig.ServiceName)
+	}
+}

--- a/client/client_retrypolicy_test.go
+++ b/client/client_retrypolicy_test.go
@@ -1,0 +1,128 @@
+package client
+
+/*
+ * Copyright 2020-2026 Aldelo, LP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The retry-policy fragment feeds gRPC's WithDefaultServiceConfig alongside the round_robin LB
+// policy. gRPC silently ignores an invalid service config, so the fragment must always parse,
+// carry a maxAttempts within gRPC's [2,5] range, and retry ONLY UNAVAILABLE (so app-level
+// errors like NOT_FOUND are never retried).
+
+type parsedRetryServiceConfig struct {
+	MethodConfig []struct {
+		Name        []map[string]any `json:"name"`
+		RetryPolicy struct {
+			MaxAttempts          int      `json:"maxAttempts"`
+			InitialBackoff       string   `json:"initialBackoff"`
+			MaxBackoff           string   `json:"maxBackoff"`
+			BackoffMultiplier    float64  `json:"backoffMultiplier"`
+			RetryableStatusCodes []string `json:"retryableStatusCodes"`
+		} `json:"retryPolicy"`
+	} `json:"methodConfig"`
+}
+
+func parseRetryConfig(t *testing.T, maxAttempts uint) parsedRetryServiceConfig {
+	t.Helper()
+	wrapped := "{" + retryPolicyServiceConfigFragment(maxAttempts) + "}"
+	var parsed parsedRetryServiceConfig
+	if err := json.Unmarshal([]byte(wrapped), &parsed); err != nil {
+		t.Fatalf("retry fragment for maxAttempts=%d is not valid JSON: %v (wrapped=%q)", maxAttempts, err, wrapped)
+	}
+	if len(parsed.MethodConfig) != 1 {
+		t.Fatalf("expected 1 methodConfig entry, got %d", len(parsed.MethodConfig))
+	}
+	return parsed
+}
+
+func TestRetryPolicyServiceConfigFragment_RetriesOnlyUnavailable(t *testing.T) {
+	parsed := parseRetryConfig(t, 3)
+	codes := parsed.MethodConfig[0].RetryPolicy.RetryableStatusCodes
+	if len(codes) != 1 || codes[0] != "UNAVAILABLE" {
+		t.Fatalf("retryableStatusCodes = %v, want exactly [UNAVAILABLE]", codes)
+	}
+}
+
+func TestRetryPolicyServiceConfigFragment_AppliesToAllMethods(t *testing.T) {
+	parsed := parseRetryConfig(t, 3)
+	names := parsed.MethodConfig[0].Name
+	if len(names) != 1 || len(names[0]) != 0 {
+		t.Fatalf("name selector = %v, want a single empty object {} (all methods)", names)
+	}
+}
+
+func TestRetryPolicyServiceConfigFragment_ClampsMaxAttempts(t *testing.T) {
+	cases := map[uint]int{
+		0:   2, // below gRPC minimum -> clamp up to 2
+		1:   2, // below gRPC minimum -> clamp up to 2
+		2:   2,
+		3:   3,
+		5:   5,
+		9:   5, // above gRPC maximum -> clamp down to 5
+		100: 5,
+	}
+	for in, want := range cases {
+		parsed := parseRetryConfig(t, in)
+		if got := parsed.MethodConfig[0].RetryPolicy.MaxAttempts; got != want {
+			t.Errorf("maxAttempts(in=%d) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestRetryPolicyServiceConfigFragment_HasBackoffFields(t *testing.T) {
+	parsed := parseRetryConfig(t, 3)
+	rp := parsed.MethodConfig[0].RetryPolicy
+	if rp.InitialBackoff == "" || rp.MaxBackoff == "" {
+		t.Fatalf("initialBackoff/maxBackoff must be set, got initial=%q max=%q", rp.InitialBackoff, rp.MaxBackoff)
+	}
+	if rp.BackoffMultiplier <= 1.0 {
+		t.Fatalf("backoffMultiplier = %v, want > 1.0", rp.BackoffMultiplier)
+	}
+}
+
+// The real dial-time assembly composes round_robin + health check + retry policy into one
+// service config; verify all three coexist as valid JSON (a broken combination would silently
+// disable load balancing AND health checking AND retries).
+func TestRetryPolicyServiceConfigFragment_ComposesWithLbAndHealthCheck(t *testing.T) {
+	lb := `"loadBalancingConfig":[{"round_robin":{}}]`
+	full := "{" + lb + ", " +
+		healthCheckServiceConfigFragment("dal-config-read-get") + ", " +
+		retryPolicyServiceConfigFragment(3) + "}"
+
+	var parsed struct {
+		LoadBalancingConfig []map[string]json.RawMessage `json:"loadBalancingConfig"`
+		HealthCheckConfig   struct {
+			ServiceName string `json:"serviceName"`
+		} `json:"healthCheckConfig"`
+		MethodConfig []json.RawMessage `json:"methodConfig"`
+	}
+	if err := json.Unmarshal([]byte(full), &parsed); err != nil {
+		t.Fatalf("composed service config is not valid JSON: %v (full=%q)", err, full)
+	}
+	if len(parsed.LoadBalancingConfig) != 1 {
+		t.Fatalf("expected round_robin LB entry, got %d entries", len(parsed.LoadBalancingConfig))
+	}
+	if parsed.HealthCheckConfig.ServiceName != "dal-config-read-get" {
+		t.Fatalf("healthCheck serviceName = %q, want dal-config-read-get", parsed.HealthCheckConfig.ServiceName)
+	}
+	if len(parsed.MethodConfig) != 1 {
+		t.Fatalf("expected 1 methodConfig entry, got %d", len(parsed.MethodConfig))
+	}
+}

--- a/client/config.go
+++ b/client/config.go
@@ -118,6 +118,16 @@ type grpcData struct {
 	// gRPC requires >= 2 and effectively caps at 5. 0/unset => default 3. Only used when
 	// RetryPolicyEnabled is true.
 	RetryPolicyMaxAttempts uint `mapstructure:"retry_policy_max_attempts"`
+	// EvictOnDialFailureEnabled turns on active dead-endpoint eviction: when a unary RPC fails to
+	// DIAL a specific endpoint (transport: error while dialing <ip:port>), the client purges just
+	// that ip:port from the discovery cache, pushes the trimmed set to the round_robin resolver,
+	// and retries the RPC once against the remaining endpoints. This delivers immediate
+	// per-request failover during the ~10-minute window in which Cloud Map still advertises a dead
+	// instance (the A2 plan, Option B). Default false preserves current behavior. Only a dial
+	// failure (connection never established => request provably never sent) triggers it, so the
+	// single retry is safe even for non-idempotent methods. Requires UseLoadBalancer and a
+	// non-direct discovery type (there must be other endpoints to fail over to).
+	EvictOnDialFailureEnabled bool `mapstructure:"evict_on_dial_failure_enabled"`
 }
 
 func (c *config) SetTargetAppName(s string) {
@@ -414,6 +424,13 @@ func (c *config) SetRetryPolicyMaxAttempts(i uint) {
 	}
 }
 
+func (c *config) SetEvictOnDialFailureEnabled(b bool) {
+	if c._v != nil {
+		c._v.Set("grpc.evict_on_dial_failure_enabled", b)
+		c.Grpc.EvictOnDialFailureEnabled = b
+	}
+}
+
 // Read will load config settings from disk.
 // FIX #1: Builds into local variables first and only overwrites c._v, c.Target, etc.
 // on success, so a failed Read() doesn't destroy previously valid state.
@@ -478,7 +495,8 @@ func (c *config) Read() error {
 		"grpc.circuit_breaker_error_percent_threshold", 50).Default(
 		"grpc.circuit_breaker_logger_enabled", true).Default(
 		"grpc.retry_policy_enabled", false).Default(
-		"grpc.retry_policy_max_attempts", 3)
+		"grpc.retry_policy_max_attempts", 3).Default(
+		"grpc.evict_on_dial_failure_enabled", false)
 
 	if ok, err := v.Init(); err != nil {
 		return err

--- a/client/config.go
+++ b/client/config.go
@@ -80,13 +80,19 @@ type topicsData struct {
 }
 
 type grpcData struct {
-	DialBlockingMode                     bool   `mapstructure:"dial_blocking_mode"`
-	ServerCACertFiles                    string `mapstructure:"server_ca_cert_files"`
-	ClientCertFile                       string `mapstructure:"client_cert_file"`
-	ClientKeyFile                        string `mapstructure:"client_key_file"`
-	UserAgent                            string `mapstructure:"user_agent"`
-	UseLoadBalancer                      bool   `mapstructure:"use_load_balancer"`
-	UseHealthCheck                       bool   `mapstructure:"use_health_check"`
+	DialBlockingMode  bool   `mapstructure:"dial_blocking_mode"`
+	ServerCACertFiles string `mapstructure:"server_ca_cert_files"`
+	ClientCertFile    string `mapstructure:"client_cert_file"`
+	ClientKeyFile     string `mapstructure:"client_key_file"`
+	UserAgent         string `mapstructure:"user_agent"`
+	UseLoadBalancer   bool   `mapstructure:"use_load_balancer"`
+	UseHealthCheck    bool   `mapstructure:"use_health_check"`
+	// HealthCheckServiceName is the grpc.health.v1 service name the client watches when
+	// UseHealthCheck is true. Empty (default) preserves the historical behavior of watching
+	// the default (unnamed) health service. Set it to the server's registered health service
+	// name so the round_robin balancer ejects subconns reporting NOT_SERVING / TRANSIENT_FAILURE
+	// — the client-side half of "auto-skip a dead instance" (the server must expose grpc.health.v1).
+	HealthCheckServiceName               string `mapstructure:"health_check_service_name"`
 	DialMinConnectTimeout                uint   `mapstructure:"dial_min_connect_timeout"`
 	KeepAliveInactivePingTimeTrigger     uint   `mapstructure:"keepalive_inactive_ping_time_trigger"`
 	KeepAliveInactivePingTimeout         uint   `mapstructure:"keepalive_inactive_ping_timeout"`
@@ -284,6 +290,13 @@ func (c *config) SetUseHealthCheck(b bool) {
 	}
 }
 
+func (c *config) SetHealthCheckServiceName(s string) {
+	if c._v != nil {
+		c._v.Set("grpc.health_check_service_name", s)
+		c.Grpc.HealthCheckServiceName = s
+	}
+}
+
 func (c *config) SetDialMinConnectTimeout(i uint) {
 	if c._v != nil {
 		c._v.Set("grpc.dial_min_connect_timeout", i)
@@ -424,6 +437,7 @@ func (c *config) Read() error {
 		"grpc.user_agent", "").Default(
 		"grpc.use_load_balancer", true).Default(
 		"grpc.use_health_check", true).Default(
+		"grpc.health_check_service_name", "").Default(
 		"grpc.dial_min_connect_timeout", 5).Default(
 		"grpc.keepalive_inactive_ping_time_trigger", 0).Default(
 		"grpc.keepalive_inactive_ping_timeout", 0).Default(

--- a/client/config.go
+++ b/client/config.go
@@ -106,6 +106,18 @@ type grpcData struct {
 	CircuitBreakerSleepWindow            uint   `mapstructure:"circuit_breaker_sleep_window"`
 	CircuitBreakerErrorPercentThreshold  uint   `mapstructure:"circuit_breaker_error_percent_threshold"`
 	CircuitBreakerLoggerEnabled          bool   `mapstructure:"circuit_breaker_logger_enabled"`
+	// RetryPolicyEnabled turns on a gRPC service-config retryPolicy that transparently retries
+	// UNAVAILABLE (e.g. a dial failure to a dead endpoint). Combined with round_robin, each retry
+	// re-picks the next subconn, so a request fails over to a live endpoint instead of returning
+	// the dial error — the "try the next IP instead of failing" requirement from the A2 plan.
+	// Default false preserves the historical behavior (retry disabled via grpc.WithDisableRetry).
+	// Enable only for idempotent read paths first; auditing blast radius across consumers is a
+	// documented prerequisite. When true, grpc.WithDisableRetry is NOT applied.
+	RetryPolicyEnabled bool `mapstructure:"retry_policy_enabled"`
+	// RetryPolicyMaxAttempts is the total attempts (original + retries) for the retryPolicy above.
+	// gRPC requires >= 2 and effectively caps at 5. 0/unset => default 3. Only used when
+	// RetryPolicyEnabled is true.
+	RetryPolicyMaxAttempts uint `mapstructure:"retry_policy_max_attempts"`
 }
 
 func (c *config) SetTargetAppName(s string) {
@@ -388,6 +400,20 @@ func (c *config) SetCircuitBreakerLoggerEnabled(b bool) {
 	}
 }
 
+func (c *config) SetRetryPolicyEnabled(b bool) {
+	if c._v != nil {
+		c._v.Set("grpc.retry_policy_enabled", b)
+		c.Grpc.RetryPolicyEnabled = b
+	}
+}
+
+func (c *config) SetRetryPolicyMaxAttempts(i uint) {
+	if c._v != nil {
+		c._v.Set("grpc.retry_policy_max_attempts", i)
+		c.Grpc.RetryPolicyMaxAttempts = i
+	}
+}
+
 // Read will load config settings from disk.
 // FIX #1: Builds into local variables first and only overwrites c._v, c.Target, etc.
 // on success, so a failed Read() doesn't destroy previously valid state.
@@ -450,7 +476,9 @@ func (c *config) Read() error {
 		"grpc.circuit_breaker_request_volume_threshold", 20).Default(
 		"grpc.circuit_breaker_sleep_window", 5000).Default(
 		"grpc.circuit_breaker_error_percent_threshold", 50).Default(
-		"grpc.circuit_breaker_logger_enabled", true)
+		"grpc.circuit_breaker_logger_enabled", true).Default(
+		"grpc.retry_policy_enabled", false).Default(
+		"grpc.retry_policy_max_attempts", 3)
 
 	if ok, err := v.Init(); err != nil {
 		return err


### PR DESCRIPTION
## What & why

After connector **v1.8.13** (PR #51, A1: forced refresh re-queries Cloud Map + reconciles) shipped, dev testing showed it did **not** eliminate the multi-minute outage when a `dal-config` instance restarts. The residual delay is **cloud-side and structurally ~10 minutes** (confirmed by the connector owner): after a restart, Cloud Map keeps advertising the dead instance for up to ~10 min (detect → 3–4 min purge trigger → couple-min deregister). During that window a round-robin client keeps landing on the dead IP and **fails the request outright**, because today the client:

- disables gRPC automatic retry (`grpc.WithDisableRetry()`),
- runs with native per-subconn health checking off (`healthCheckConfig.serviceName:""`),
- has nothing that evicts a dead endpoint on a dial failure — the DAL wrapper's coarse "refresh + retry once" can re-land on the same still-registered dead IP.

Per the owner's explicit request (*"on detect ip is dead, remove that ip and try next ip set … faster recovery built into client side"*), this PR adds **client-side fast failover** so a request **fails over within itself** instead of erroring for ~10 minutes. It implements **both** options from the A2 fix plan:

- **Option A** — let gRPC's own machinery do transparent failover: a configurable health-check service name + an opt-in `UNAVAILABLE` retry policy.
- **Option B** — an explicit evict-the-dead-endpoint-and-retry accelerator that works even without server-side health support.

**Everything is config-gated and defaults to OFF.** Merging changes no runtime behavior until an operator opts in; this keeps the blast radius (especially re-enabling gRPC retry) strictly opt-in per the plan's §7.

## How (3 commits, each an independent logical change)

| # | Commit | Change | Plan |
|---|--------|--------|------|
| 1 | `0456556` | **Configurable gRPC health-check service name.** New `grpc.health_check_service_name` (default `""` = current behavior). Non-empty ⇒ round_robin ejects subconns whose `grpc.health.v1` status is NOT_SERVING. Fragment built by a pure, JSON-escaping helper (gRPC silently ignores invalid service-config JSON). | A #1 |
| 2 | `4638b66` | **Opt-in gRPC retry policy for transparent failover.** New `grpc.retry_policy_enabled` (default `false`) + `grpc.retry_policy_max_attempts` (default 3, clamped to gRPC's [2,5]). When on, attaches a `retryPolicy` scoped to `UNAVAILABLE` and **skips `WithDisableRetry()`** — with round_robin, each retry re-picks the next subconn = transparent failover. Default off ⇒ byte-for-byte prior behavior. | A #2 |
| 3 | `c569625` | **Evict dead endpoint + fail over on dial failure.** New `grpc.evict_on_dial_failure_enabled` (default `false`). Innermost unary interceptor: on `transport: error while dialing: dial tcp <ip>:<port>`, purge just that ip:port (reusing the SNS offline handler's `cachePurgeServiceEndpointByHostAndPort → setEndpoints → UpdateLoadBalanceResolver` path), then retry once against the trimmed set. Pure, unit-tested host:port parser. | B |

Options A and B are **independent and composable**: A is gRPC-native transparent failover (its health-check half needs a server-side health service); B is an explicit accelerator that works even without server-side health support.

## Fix scope (this is a *client-side* fix)

This changes only **`connector/client`** — the **dialing** side. **Any service, whether an HTTP service or a gRPC service, benefits automatically whenever it acts as a client calling a BLL-layer or DAL-layer gRPC service. The callee (the BLL/DAL server) needs no code change to grant that benefit.** Concretely that includes the `*-portal-api` HTTP services, the `bll-*-service` gRPC services (when they in turn call downstream DAL/BLL), and any DAL service acting as a client.

It does **not** change the server-side *receive* path of a DAL/BLL service; Option A's health-check half additionally needs each server to register `grpc.health.v1`, and the ~10-min cloud cleanup remains the reconciler's job.

**To activate**, a consumer bumps `github.com/aldelo/connector` to **v1.8.14** (the tag cut from this branch once merged), rebuilds, and sets the relevant config flag(s). Clients that have **not** upgraded simply ignore the new unknown YAML keys (viper/mapstructure drops unknown fields), so the config can be written in full ahead of the upgrade with no effect until the binary is on v1.8.14.

## Verification

**Toolchain:** Go 1.26.4. **Diff:** 5 files, +688/−11; **no `go.mod`/`go.sum` changes.**

Executed locally, all green:

```
go build ./...                 # exit 0
go vet ./...                   # exit 0
gofmt -l client/               # no output (clean)
go test ./client/ -race -count=1 \
   -skip 'SurvivesPanicHandler|SafeCallRecoversPanic|SafeGoRecoversPanic|TestClient_Dial'   # ok
```

- **16 new unit tests** across 3 files (health-check fragment ×4, retry-policy fragment ×5, parser + interceptor gating ×7). All pass, including under `-race`.
- The skipped tests are **pre-existing and unrelated**: the `*SurvivesPanicHandler` / `SafeCall|SafeGoRecoversPanic` family is the known flake #52 (a test-injected panic aborts the `go test` process on recovery); `TestClient_Dial` is an integration test that dials a live gRPC server and runs 1000 RPCs (no server in the CI sandbox). Both fail identically on unmodified `master` — verified before starting.

**Plan §6 dev verification (NOT run here — needs the dev environment).** Planned pilot: **5 services across 3 repos** — 3 HTTP `*-portal-api` (`go-ms-apgs-control-portal-api`, `go-ms-apgs-tms-portal-api`, `go-ms-apgs-web-portals-api`) + 2 gRPC `bll-*-service`. Steps QA can run once a v1.8.14 build with the flags is deployed to those services' wrapper chain:

1. Bump the pilot binaries to connector v1.8.14; set the new flags in the endpoint YAML (see below); deploy to dev.
2. Restart `dal-config` (creates fresh dead IPs in Cloud Map for ~10 min); **do not restart the business.**
3. From each portal, hammer the previously-failing read path (`GetConfigItemByEnum`, a fixed `MerchantAccountGid`) **during** the ~10-min cloud-cleanup window.
4. **Pass:** individual requests **succeed** (transparent failover to a live endpoint) instead of returning `transport: error while dialing`, even though dead IPs are still registered in Cloud Map. At most a brief bounded blip is acceptable; sustained multi-minute failure is not.
5. Confirm no regression to the ~30s A1 background convergence.

Once the pilot passes, roll the same config out to `go-ms-remote-connector-apgs` + `go-ms-remote-connector-dal` and the remaining repos.

**Example endpoint-YAML `grpc:` block (all new keys written together):**

```yaml
grpc:
  # ... existing keys ...
  evict_on_dial_failure_enabled: true    # Option B: evict dead ip + retry once
  retry_policy_enabled: true             # Option A: transparent failover via gRPC retry
  retry_policy_max_attempts: 3           # clamped to [2,5]
  health_check_service_name: ""          # Option A: set to the server's grpc.health.v1
                                         # name ONLY if that server registers it; leaving
                                         # it "" keeps prior behavior. A wrong/non-served
                                         # name makes health checks mark subconns unhealthy.
```

## Open coordination items

- **Option A health-check half** needs the target servers (`dal-config`, etc.) to expose `grpc.health.v1` before setting a non-empty `health_check_service_name` — server-side, out of this repo's scope.
- **Retry-policy blast radius:** audit before enabling broadly; scope to idempotent reads first. (Option B's single retry is safe regardless — a dial failure means the request never left the client.)
- **Release:** additive, backward-compatible, opt-in → suggest a **patch** bump to **v1.8.14**. Branch pushed only; **no PR auto-merge** — owner merges.

---

*Per-commit deep-dives (what/why/how, safety, tests) are added as three follow-up review comments, one per commit.*
