### PR TITLE
fix(client): per-connection manual resolver isolation (stale-IP never-heals root cause)

### DIFF
--- a/adapters/loadbalancer/roundrobin.go
+++ b/adapters/loadbalancer/roundrobin.go
@@ -159,3 +159,12 @@ func WithRoundRobin(schemeName string, serviceName string, endpointAddrs []strin
 
 	return target, loadBalancerPolicy, nil
 }
+
+// RoundRobinServiceConfigPolicy returns the round-robin service-config JSON *fragment* (without
+// outer braces), identical to what WithRoundRobin returns as loadBalancerPolicy. It exists so a
+// caller that builds its OWN resolver instance (see resolver.NewManualResolverInstance) can obtain
+// the same LB policy without going through WithRoundRobin's process-global resolver registration.
+// The caller wraps this in fmt.Sprintf(`{%s}`, policy) exactly as it does WithRoundRobin's return.
+func RoundRobinServiceConfigPolicy() string {
+	return `"loadBalancingConfig":[{"round_robin":{}}]`
+}

--- a/adapters/resolver/resolver.go
+++ b/adapters/resolver/resolver.go
@@ -280,6 +280,65 @@ func UpdateManualResolver(schemeName string, serviceName string, endpointAddrs [
 	return nil
 }
 
+// NewManualResolverInstance creates a NEW *manual.Resolver bound to a SINGLE caller (a single
+// grpc.ClientConn), WITHOUT storing it in the process-global schemeMap. It is the per-connection
+// counterpart of NewManualResolver: the caller keeps the returned resolver on its own struct and
+// passes it into its own Dial via grpc.WithResolvers(...), then drives it with
+// UpdateManualResolverInstance. This guarantees the grpc-go manual.Resolver contract ("every
+// instance may only ever be used with a single grpc.ClientConn") structurally, so one caller's
+// endpoint refresh can never overwrite another caller's connection (the shared-resolver orphaning
+// bug). The existing global NewManualResolver/UpdateManualResolver are left intact for other callers.
+//
+// Returns the resolver instance plus the normalized scheme and service (the caller builds its dial
+// target as "<scheme>:///<service>"). Validation mirrors NewManualResolver exactly (same
+// normalizers, same error shapes).
+func NewManualResolverInstance(schemeName string, serviceName string, endpointAddrs []string) (r *manual.Resolver, normalizedScheme string, normalizedService string, err error) {
+	schemeName, err = normalizeAndValidateSchemeName(schemeName)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	svc, err := normalizeServiceName(serviceName)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	addrs, err := normalizeAddresses(endpointAddrs, nil)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	res := manual.NewBuilderWithScheme(schemeName)
+	res.InitialState(resolver.State{
+		Addresses: addrs,
+	})
+
+	return res, schemeName, svc, nil
+}
+
+// UpdateManualResolverInstance pushes a fresh address set into a caller-owned *manual.Resolver
+// (obtained from NewManualResolverInstance). It is the per-connection counterpart of
+// UpdateManualResolver, but targets the passed instance directly instead of a global-map lookup,
+// so the update always lands on the caller's OWN connection. Nil-guards match the global path's
+// "resolver is nil" failure shape (no panic).
+func UpdateManualResolverInstance(r *manual.Resolver, endpointAddrs []string) error {
+	if r == nil {
+		return fmt.Errorf("manual resolver instance is nil")
+	}
+
+	addrs, err := normalizeAddresses(endpointAddrs, fmt.Errorf("Endpoint Addresses Required"))
+	if err != nil {
+		return err
+	}
+
+	r.UpdateState(resolver.State{
+		Addresses: addrs,
+	})
+
+	log.Println("[NOTE] Please Ignore Error 'Health check is requested but health check function is not set'; UpdateManualResolverInstance is Completed")
+	return nil
+}
+
 func setResolver(schemeName string, serviceName string, r *manual.Resolver) error {
 	if r == nil {
 		return fmt.Errorf("Resolver is nil; cannot register")

--- a/adapters/resolver/resolver_instance_test.go
+++ b/adapters/resolver/resolver_instance_test.go
@@ -1,0 +1,108 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for the per-connection owned-resolver API (NewManualResolverInstance /
+// UpdateManualResolverInstance) added to fix the shared-resolver orphaning bug.
+// See go-ms-shared/docs/xieyanlei/dal-config-stale-ip-shared-resolver-FIX-plan.md §4/§8.
+
+// (a) NewManualResolverInstance returns a usable resolver + normalized scheme/service,
+//     and does NOT register into the process-global schemeMap.
+func TestNewManualResolverInstance_ReturnsInstanceWithoutGlobalRegistration(t *testing.T) {
+	r, scheme, svc, err := NewManualResolverInstance("CLBFoo", "My-Service.My-NS", []string{"10.0.0.1:5000"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected a non-nil *manual.Resolver instance")
+	}
+	if scheme != "clbfoo" {
+		t.Errorf("normalized scheme = %q; want %q", scheme, "clbfoo")
+	}
+	if svc != "my-service.my-ns" {
+		t.Errorf("normalized service = %q; want %q", svc, "my-service.my-ns")
+	}
+	if r.Scheme() != scheme {
+		t.Errorf("resolver.Scheme() = %q; want %q", r.Scheme(), scheme)
+	}
+	// It must NOT have been stored in the global schemeMap (that is the whole point:
+	// an owned instance is local to one ClientConn, not shared via the global map).
+	if got, gerr := getResolver(scheme, svc); gerr == nil && got != nil {
+		t.Errorf("owned instance must NOT be registered in the global schemeMap; getResolver found one")
+	}
+}
+
+// (a') same validation/error shapes as the global path.
+func TestNewManualResolverInstance_RejectsBadInputs(t *testing.T) {
+	if _, _, _, err := NewManualResolverInstance("", "svc.ns", []string{"10.0.0.1:5000"}); err == nil {
+		// empty scheme normalizes to "clb" (valid) — so this is NOT an error; document that.
+		// (kept for parity awareness; empty scheme is allowed via normalizeSchemeName default)
+		_ = err
+	}
+	if _, _, _, err := NewManualResolverInstance("clbfoo", "", []string{"10.0.0.1:5000"}); err == nil {
+		t.Error("expected error for empty service name")
+	}
+	if _, _, _, err := NewManualResolverInstance("clbfoo", "svc.ns", nil); err == nil {
+		t.Error("expected error for empty endpoint addresses")
+	}
+	// a bare IP literal with no port is explicitly rejected by normalizeAddresses.
+	if _, _, _, err := NewManualResolverInstance("clbfoo", "svc.ns", []string{"10.0.0.1"}); err == nil {
+		t.Error("expected error for invalid endpoint address (bare IP missing port)")
+	}
+}
+
+// (b) THE CORE ANTI-ORPHAN GUARANTEE: two independent instances do not share state.
+//     Updating instance A must not affect instance B — this is what the global-map
+//     sharing violated (one Update overwrote another conn's resolver).
+func TestOwnedResolverInstances_AreIndependent(t *testing.T) {
+	rA, _, _, err := NewManualResolverInstance("clbsame", "dal-config-read-get-service.dev.aldelo.nae", []string{"10.0.0.1:5000"})
+	if err != nil {
+		t.Fatalf("build A: %v", err)
+	}
+	rB, _, _, err := NewManualResolverInstance("clbsame", "dal-config-read-get-service.dev.aldelo.nae", []string{"10.0.0.2:5000"})
+	if err != nil {
+		t.Fatalf("build B: %v", err)
+	}
+	// Even with the SAME scheme+service (the exact collision that caused orphaning in the
+	// global map), the two instances are distinct objects.
+	if rA == rB {
+		t.Fatal("expected two DISTINCT resolver instances for the same scheme+service; got the same pointer")
+	}
+
+	// Updating A must succeed and must not error/panic on B independently.
+	if e := UpdateManualResolverInstance(rA, []string{"10.0.0.9:5000"}); e != nil {
+		t.Errorf("UpdateManualResolverInstance(A) unexpected error: %v", e)
+	}
+	if e := UpdateManualResolverInstance(rB, []string{"10.0.0.8:5000"}); e != nil {
+		t.Errorf("UpdateManualResolverInstance(B) unexpected error: %v", e)
+	}
+	// (State isolation is guaranteed structurally: each manual.Resolver holds its own
+	// lastSeenState/cc; there is no shared map entry. The distinct-pointer assertion above
+	// plus independent successful updates capture the anti-orphan property at unit level;
+	// end-to-end IP divergence is covered by /diag/resolver-collision, pilot §8.15.)
+}
+
+// UpdateManualResolverInstance nil-guard matches the global path's "resolver is nil" shape.
+func TestUpdateManualResolverInstance_NilResolver(t *testing.T) {
+	err := UpdateManualResolverInstance(nil, []string{"10.0.0.1:5000"})
+	if err == nil {
+		t.Fatal("expected error for nil resolver instance")
+	}
+	if !strings.Contains(err.Error(), "nil") {
+		t.Errorf("error %q should mention nil", err.Error())
+	}
+}
+
+// UpdateManualResolverInstance rejects empty address set (parity with global UpdateManualResolver).
+func TestUpdateManualResolverInstance_EmptyAddrs(t *testing.T) {
+	r, _, _, err := NewManualResolverInstance("clbfoo", "svc.ns", []string{"10.0.0.1:5000"})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if e := UpdateManualResolverInstance(r, nil); e == nil {
+		t.Error("expected error for empty endpoint addresses on update")
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -60,6 +60,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
+	manualresolver "google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 )
@@ -281,6 +282,9 @@ func (c *Client) clearConnection() *grpc.ClientConn {
 	c._conn = nil
 	c._remoteAddress = ""
 	c._healthManualChecker = nil
+	// drop this Client's owned resolver alongside its conn; Dial rebuilds a fresh one. Keeps the
+	// resolver 1:1 with the conn across Close()+Dial() cycles (no stale instance, no orphan).
+	c._resolver = nil
 	c.connMu.Unlock()
 	return conn
 }
@@ -462,6 +466,14 @@ type Client struct {
 	// instantiated internal objects
 	_conn          *grpc.ClientConn
 	_remoteAddress string
+
+	// _resolver is this Client's OWN manual resolver instance, built in Dial and passed into
+	// this Client's ClientConn via grpc.WithResolvers. It is 1:1 with _conn: endpoint refreshes
+	// (GetLiveEndpointsCount / UpdateLoadBalanceResolver) drive THIS resolver, so they can never
+	// overwrite another Client's connection (the shared-resolver orphaning bug). Nil in "direct"
+	// discovery mode (no round-robin resolver) and after Close. Written only under _lifecycleMu
+	// (Dial / Close), read on the refresh paths after Dial has completed.
+	_resolver *manualresolver.Resolver
 
 	// upon dial completion successfully,
 	// auto instantiate a manual help checker
@@ -1703,18 +1715,24 @@ func (c *Client) Dial(ctx context.Context) error {
 	var loadBalancerPolicy string
 
 	if cfg.Target.ServiceDiscoveryType != "direct" {
-		var err error
-
 		// very important: client load balancer scheme name must be alpha and lower cased
 		//                 if scheme name is not valid, error will occur: transport error, tcp port unknown
 		schemeName, _ := util.ExtractAlpha(cfg.AppName)
 		schemeName = strings.ToLower("clb" + schemeName)
 
-		target, loadBalancerPolicy, err = loadbalancer.WithRoundRobin(schemeName, fmt.Sprintf("%s.%s", cfg.Target.ServiceName, cfg.Target.NamespaceName), endpointAddrs)
-
-		if err != nil {
-			return fmt.Errorf("build client load balancer failed: %w", err)
+		// Build a resolver instance OWNED BY THIS Client (not stored in the process-global
+		// schemeMap), so this ClientConn is 1:1 with its resolver and endpoint refreshes can
+		// never overwrite another Client's connection (the shared-resolver orphaning bug). The
+		// instance is passed into this Dial via grpc.WithResolvers below. See
+		// go-ms-shared/docs/xieyanlei/dal-config-stale-ip-shared-resolver-FIX-plan.md.
+		serviceFqdn := fmt.Sprintf("%s.%s", cfg.Target.ServiceName, cfg.Target.NamespaceName)
+		r, normScheme, normSvc, e := res.NewManualResolverInstance(schemeName, serviceFqdn, endpointAddrs)
+		if e != nil {
+			return fmt.Errorf("build client load balancer failed: %w", e)
 		}
+		c._resolver = r
+		target = fmt.Sprintf("%s:///%s", normScheme, normSvc)
+		loadBalancerPolicy = loadbalancer.RoundRobinServiceConfigPolicy()
 	} else {
 		target = fmt.Sprintf("%s:///%s", "passthrough", endpointAddrs[0])
 		loadBalancerPolicy = ""
@@ -1724,6 +1742,14 @@ func (c *Client) Dial(ctx context.Context) error {
 	if opts, err := c.buildDialOptions(loadBalancerPolicy); err != nil {
 		return fmt.Errorf("build gRPC client dial options failed: %w", err)
 	} else {
+		// Register THIS Client's own manual resolver locally to this ClientConn (non-direct mode
+		// only). WithResolvers is scoped to this Dial and takes precedence over the global
+		// registry, so no other Client shares it — this is what makes the connection 1:1 with its
+		// resolver and prevents the orphaning bug.
+		if c._resolver != nil {
+			opts = append(opts, grpc.WithResolvers(c._resolver))
+		}
+
 		if c.BeforeClientDial != nil {
 			if z := c.ZLog(); z != nil {
 				z.Printf("Before gRPC Client Dial Begin...")
@@ -2068,12 +2094,9 @@ func (c *Client) GetLiveEndpointsCount(updateEndpointsToLoadBalanceResolver bool
 			return 0, errors.New(s)
 		}
 
-		// update load balance resolver with new endpoint addresses
-		serviceName := fmt.Sprintf("%s.%s", cfg.Target.ServiceName, cfg.Target.NamespaceName)
-		schemeName, _ := util.ExtractAlpha(cfg.AppName)
-		schemeName = strings.ToLower("clb" + schemeName)
-
-		if e := res.UpdateManualResolver(schemeName, serviceName, endpointAddrs); e != nil {
+		// update THIS Client's own load balance resolver with new endpoint addresses (drives the
+		// resolver bound to this Client's ClientConn — never another Client's; see FIX-plan §5).
+		if e := res.UpdateManualResolverInstance(c._resolver, endpointAddrs); e != nil {
 			errorf("GetLiveEndpointsCount-UpdateLoadBalanceResolver for Client %s with Service '%s.%s' Failed: %s",
 				cfg.AppName, cfg.Target.ServiceName, cfg.Target.NamespaceName, e.Error())
 			return 0, e
@@ -2174,13 +2197,9 @@ func (c *Client) UpdateLoadBalanceResolver() error {
 		printf("%s", "       - "+info)
 	}
 
-	// update load balance resolver with new endpoint addresses
-	serviceName := fmt.Sprintf("%s.%s", cfg.Target.ServiceName, cfg.Target.NamespaceName)
-
-	schemeName, _ := util.ExtractAlpha(cfg.AppName)
-	schemeName = strings.ToLower("clb" + schemeName)
-
-	if e := res.UpdateManualResolver(schemeName, serviceName, endpointAddrs); e != nil {
+	// update THIS Client's own load balance resolver with new endpoint addresses (drives the
+	// resolver bound to this Client's ClientConn — never another Client's; see FIX-plan §5).
+	if e := res.UpdateManualResolverInstance(c._resolver, endpointAddrs); e != nil {
 		errorf("UpdateLoadBalanceResolver for Client %s with Service '%s.%s' Failed: %s",
 			cfg.AppName, cfg.Target.ServiceName, cfg.Target.NamespaceName, e.Error())
 		return e


### PR DESCRIPTION
## Summary

Fix the root cause of the dal-config gRPC stale-IP failures where a caller keeps dialing dead
instance IPs after the dal-config servers are restarted, and **never self-heals** until the caller
process itself is restarted.

The connector kept **one shared `*manual.Resolver` per `scheme:service` in a process-global map**
and reused it across **every** `grpc.ClientConn`. grpc-go's manual resolver may only ever be bound
to a **single** `ClientConn` (its own doc: *"Every instance of the manual resolver may only ever be
used with a single grpc.ClientConn. Otherwise, bad things will happen."*). When a process builds two
or more `Client`s on the same `scheme:service`, all but the last-dialed connection are **orphaned**:
their endpoint refresh updates the wrong connection, so their address set is frozen at dial time and
they round-robin over dead IPs forever.

This PR makes the resolver **1:1 with the `ClientConn`**: each `Client` builds and owns its own
`*manual.Resolver` and passes it into its own dial via `grpc.WithResolvers(...)`. Endpoint refreshes
then drive **that** connection's resolver, so a refresh can never overwrite another connection.

---

## Trigger conditions

- The failure appears when the **dal-config server pods are restarted** (their pod IPs change), while
  the caller (portal) process keeps running.
- It bites a caller **process** only when that process builds **two or more** connector `Client`s on
  the **same** `scheme:service` — which happens because the shared data-access layer builds **one
  client per app enum** (e.g. `AC-Central`, `AC-ePay`, `AC-Control`, …) against the same dal-config
  sub-services. A process with ≥2 app enums has ≥2 connections sharing one resolver.
- Observed gradient across our three portals under the identical build/config:
  - the aggregator portal that drives **≥3 app enums always** failed;
  - a portal that drives **1 app enum** converged/self-healed;
  - a portal that dials dal-config **~0 times directly** (it relays through another service) was
    mostly unaffected.

## Symptoms

1. Once the errors start they **never self-heal** — not even after an hour of continuous requests.
2. The dialed IP **rotates**, but only ever among **the same handful of dead IPs**; it was **never**
   observed to land on a live IP.
3. The client-side recovery path **runs and reports success** — `GetLiveEndpointsCount(true)` returns
   "OK, N live endpoints" — yet the **very next** RPC still hits the same dead IP.
4. **Restarting the caller process always fixes it, immediately and reliably.** Restarting the
   dal-config servers causes it; restarting the caller after that clears it.
5. Errors are a family of dial failures: `connect: no route to host`, `connect: connection timed
   out`, `i/o timeout`, `connect: connection refused`, plus `hystrix: circuit open` (no IP) once the
   breaker trips.

The decisive observation: `GetLiveEndpointsCount(true)` fetches the current live IPs and reports
success, but the next call on the cached service stub still dials the old dead IP — i.e. the fresh
live IPs are **not being applied to the connection that stub actually uses**. And a caller restart
"fixes" it even though it cannot possibly clean anything server-side — proving the stale IPs live in
**client-side connection state**, not in the registry.

## Root cause

- The resolver scheme is a **constant per sub-service**: `"clb" + ExtractAlpha(cfg.AppName)`, where
  `cfg.AppName` is the hardcoded first argument to `client.NewClient(...)` (not a per-tenant value).
  So every `Client` built for the same sub-service computes the **same** `scheme:service`.
- `adapters/resolver` stored **one** `*manual.Resolver` per `scheme:service` in a **process-global**
  map (`schemeMap`) and reused it on every dial.
- In grpc-go, `manual.Resolver` holds a **single** `cc` field: each `Build()` does `r.cc = cc`
  (**last dial wins**) and `UpdateState()` pushes addresses **only** to that one `cc`.

Therefore, with ≥2 `Client`s on the same `scheme:service`, the **last** connection dialed wins
`r.cc`; every earlier connection is **orphaned**. An orphaned connection's cached service stub still
points at it, but its refresh — `GetLiveEndpointsCount` / `UpdateLoadBalanceResolver` →
`UpdateManualResolver` → `r.UpdateState(freshLiveIPs)` — pushes the fresh IPs to `r.cc` (a *different*
connection). The orphaned connection's address set is frozen at its dial-time IPs; after a
dal-config restart kills those, it round-robins over a 100%-dead set forever and only a process
restart (which re-dials every connection against the current live snapshot) clears it.

This directly explains every symptom: never heals (orphan never re-addressed), rotates only among
dead IPs (frozen dial-time set; live IPs went to another connection), refresh "succeeds" but the RPC
still fails (refresh landed on the wrong connection), restart always cures (all connections re-dial),
and prior evict/grace/reconcile work didn't help (those also drive the resolver via the same
shared-map update, so they too landed on the wrong connection).

## How this was confirmed before the fix

A temporary, read-only diagnostic on the aggregator portal probed, per app enum, which IPs each
cached connection actually dials (via `grpc.Peer`) and cross-checked against the registry's current
live IP set. During a real failing window (after a dal-config restart), on the **same**
`read-get-service`:

- exactly **one** app enum's connection reached the **live** IPs (it was the last-dialed connection =
  `r.cc`);
- **every other** app enum's connection dialed only **dead** IPs (absent from the current live set),
  or was circuit-open on a dead set;
- the diagnostic's own registry lookup returned **only the live IPs** — i.e. the registry was clean.

"One connection healthy, the rest permanently dead, all on the same service, with a clean registry"
is a signature that only the shared-resolver orphaning can produce — it excludes both "registry
serves stale records" (all connections to one service would see the same set) and grace/TTL
hysteresis (which would affect all connections of that service equally and clear within its window).

## The fix

Each `Client` now **owns** its resolver instance, so the resolver is structurally 1:1 with the
`ClientConn` and no update can cross connections.

- **`adapters/resolver` — two new functions (additive; existing global funcs untouched):**
  - `NewManualResolverInstance(schemeName, serviceName string, endpointAddrs []string)
    (*manual.Resolver, normalizedScheme, normalizedService string, err error)` — builds a
    `*manual.Resolver` with `InitialState` and returns it **without** storing it in the global
    `schemeMap`. Validation reuses the existing normalizers, so scheme/service/address rules and
    error shapes match the global path exactly.
  - `UpdateManualResolverInstance(r *manual.Resolver, endpointAddrs []string) error` — pushes a
    fresh address set into the **passed** resolver instance directly (no global-map lookup), with a
    nil-guard that mirrors the global path's "resolver is nil" failure shape.

- **`adapters/loadbalancer` — one new helper (additive):**
  - `RoundRobinServiceConfigPolicy() string` — returns the same round-robin service-config JSON
    fragment `WithRoundRobin` returns, so the owned-resolver path gets the identical LB policy
    without going through `WithRoundRobin`'s global resolver registration. `WithRoundRobin` itself is
    unchanged.

- **`client` — Client owns and drives its resolver:**
  - New field `Client._resolver *manual.Resolver`, 1:1 with `_conn` (written only under
    `_lifecycleMu` in Dial/Close; nil in `direct` discovery mode and after Close).
  - `Dial` (non-`direct` branch): instead of registering a shared resolver via `WithRoundRobin`, it
    builds its own instance with `NewManualResolverInstance`, stores it on `_resolver`, sets the dial
    `target` (`scheme:///service`) and LB policy from `RoundRobinServiceConfigPolicy()`, and appends
    `grpc.WithResolvers(c._resolver)` to the dial options. `WithResolvers` registers the resolver
    **locally to that one `ClientConn`** (it takes precedence over the global registry and is not
    globally registered), which is what makes the connection 1:1 with its resolver.
  - `GetLiveEndpointsCount` and `UpdateLoadBalanceResolver`: the two refresh sites now call
    `UpdateManualResolverInstance(c._resolver, endpointAddrs)` instead of the global
    `UpdateManualResolver(scheme, service, addrs)`, so a refresh always lands on this connection's own
    resolver. The now-unused local scheme/service derivations in those two blocks were removed.
  - `clearConnection` nulls `_resolver` alongside `_conn`, keeping them 1:1 across Close()+Dial()
    cycles (Dial rebuilds a fresh instance; no stale instance, no orphan).

The process-global `schemeMap` path (`NewManualResolver` / `UpdateManualResolver` / `getResolver` /
`setResolver`) is **left intact** for any other consumer; it is simply no longer on this client's
path. `direct` discovery mode is unchanged (no round-robin resolver is built; the refresh sites
already early-return for `direct`, and `UpdateManualResolverInstance` nil-guards regardless).

Why this is complete for the observed bug: the orphaning was caused solely by multiple connections
sharing one resolver instance via the global map. With each connection owning its resolver, a
refresh has no path to another connection's address set, so an orphaned/frozen connection cannot
occur. Circuit-breaker identity (keyed by gRPC method, per-`Client`), request headers, and service
discovery keys are all independent of the resolver wiring and are unchanged.

## Code changes (by file)

- `adapters/resolver/resolver.go` — add `NewManualResolverInstance`, `UpdateManualResolverInstance`
  (existing global functions unchanged).
- `adapters/resolver/resolver_instance_test.go` — new unit tests: instance creation + normalized
  scheme/service; input-validation parity; **the anti-orphan guarantee** (same `scheme:service` still
  yields distinct, independent instances); nil-resolver and empty-address guards.
- `adapters/loadbalancer/roundrobin.go` — add `RoundRobinServiceConfigPolicy()` (`WithRoundRobin`
  unchanged).
- `client/client.go` — add `Client._resolver`; build/own it in `Dial` via `grpc.WithResolvers`; drive
  it in the two refresh sites via `UpdateManualResolverInstance`; null it in `clearConnection`.

## Testing done in this PR

- `go build ./...` — clean.
- `go vet ./adapters/resolver/... ./adapters/loadbalancer/... ./client/...` — clean.
- `go test ./adapters/resolver/... ./adapters/loadbalancer/...` — pass (incl. the new
  owned-resolver tests).
- `go test ./client/...` — pass, excluding `TestClient_Dial`, which is a **pre-existing**
  environment/integration test (documented "run manually") that requires a live dal-config + AWS and
  fails offline on `master` as well; it is unrelated to this change.

## Verification after merge (to be completed on dev)

This change must be validated end-to-end on dev after merge/tag, because the pre-fix diagnostics
showed the bug is only fully exercised in a running multi-app-enum process:

1. Deploy the connector version that includes this fix to the aggregator portal on dev.
2. Restart the 6 dal-config microservices, then re-run the per-app-enum dial diagnostic during the
   window that previously failed.
3. **Expected result:** for **every** app enum and for both read-get and read-list, the connection
   reaches the current live IPs (no connection is stuck dialing only dead IPs) and the previously
   never-healing app enums self-heal within one refresh cycle without a portal restart. The
   circuit-open collateral on the healthy connection should also disappear once no connection is
   stuck failing.
4. If any connection is still observed frozen on dead IPs after this fix, that indicates a residual
   path and must be investigated before closing — the goal is a complete fix, not a partial one.

## Rollback

The change is isolated to the owned-resolver wiring (one struct field, two new resolver functions,
one loadbalancer helper, the Dial block, the two refresh-site swaps, one line in `clearConnection`).
Reverting this PR (or pinning back to the prior connector version) fully restores previous behavior;
the global `schemeMap` functions are untouched, so nothing else is affected.
